### PR TITLE
[FEAT] TL1, QnA RAG 청크 분할 기능 구현

### DIFF
--- a/rag/scripts/build_qna_chunks.py
+++ b/rag/scripts/build_qna_chunks.py
@@ -1,91 +1,13 @@
 import argparse
-import json
 from pathlib import Path
 
+from chunk_module import (
+    chunk_by_paragraph,
+    load_jsonl,
+    make_chunk_id_base,
+    write_jsonl,
+)
 from preprocess_module import OUTPUT_DIR
-
-
-def load_jsonl(path: Path):
-    rows = []
-    with path.open("r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            rows.append(json.loads(line))
-    return rows
-
-
-def write_jsonl(path: Path, rows):
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
-        for row in rows:
-            f.write(json.dumps(row, ensure_ascii=False) + "\n")
-
-
-def split_fixed(text: str, chunk_size: int, overlap: int):
-    text = (text or "").strip()
-    if not text:
-        return []
-    if chunk_size <= 0:
-        raise ValueError("chunk_size must be > 0")
-    if overlap < 0:
-        raise ValueError("overlap must be >= 0")
-    if overlap >= chunk_size:
-        raise ValueError("overlap must be smaller than chunk_size")
-
-    chunks = []
-    step = chunk_size - overlap
-    start = 0
-    while start < len(text):
-        end = min(start + chunk_size, len(text))
-        chunk = text[start:end].strip()
-        if chunk:
-            chunks.append(chunk)
-        if end >= len(text):
-            break
-        start += step
-    return chunks
-
-
-def split_by_paragraph(text: str, chunk_size: int, overlap: int):
-    text = (text or "").strip()
-    if not text:
-        return []
-
-    paragraphs = [p.strip() for p in text.split("\n") if p.strip()]
-    if not paragraphs:
-        return []
-
-    chunks = []
-    current = ""
-
-    for para in paragraphs:
-        if not current:
-            current = para
-            continue
-
-        merged = f"{current}\n{para}"
-        if len(merged) <= chunk_size:
-            current = merged
-        else:
-            chunks.append(current)
-            if overlap > 0 and len(current) > overlap:
-                carry = current[-overlap:].strip()
-                current = f"{carry}\n{para}" if carry else para
-            else:
-                current = para
-
-    if current:
-        chunks.append(current)
-
-    refined = []
-    for chunk in chunks:
-        if len(chunk) <= chunk_size:
-            refined.append(chunk)
-            continue
-        refined.extend(split_fixed(chunk, chunk_size=chunk_size, overlap=overlap))
-    return refined
 
 
 def dedup_rows(rows):
@@ -93,20 +15,13 @@ def dedup_rows(rows):
     deduped = []
 
     for row in rows:
-        key = (row.get("doc_id"), (row.get("text") or "").strip())
+        dedup_text = (row.get("rag_text") or row.get("text") or "").strip()
+        key = (row.get("doc_id"), row.get("source_file"), dedup_text)
         if key in seen:
             continue
         seen.add(key)
         deduped.append(row)
     return deduped
-
-
-def build_chunk_base_id(row, fallback_idx: int):
-    #같은 doc_id가 여러 파일에 존재할 수 있기 때문에 chunk_id 중복을 막기 위해 doc_id와 source_file 이름을 함께 사용한다. 
-    doc_id = str(row.get("doc_id", fallback_idx))
-    source_file = str(row.get("source_file", ""))
-    source_stem = Path(source_file).stem if source_file else f"row{fallback_idx}"
-    return f"{doc_id}::{source_stem}"
 
 
 def build_qna_paragraph_chunks(input_jsonl: Path, output_jsonl: Path, chunk_size: int, overlap: int):
@@ -119,11 +34,11 @@ def build_qna_paragraph_chunks(input_jsonl: Path, output_jsonl: Path, chunk_size
         if not text:
             continue
 
-        chunks = split_by_paragraph(text, chunk_size=chunk_size, overlap=overlap)
+        chunks = chunk_by_paragraph(text, chunk_size=chunk_size, overlap=overlap)
         if not chunks:
             continue
 
-        base_id = build_chunk_base_id(row, idx)
+        base_id = make_chunk_id_base(row, idx)
         for chunk_index, chunk_text in enumerate(chunks):
             chunk_row = {
                 **row,

--- a/rag/scripts/build_qna_chunks.py
+++ b/rag/scripts/build_qna_chunks.py
@@ -1,0 +1,167 @@
+import argparse
+import json
+from pathlib import Path
+
+from preprocess_module import OUTPUT_DIR
+
+
+def load_jsonl(path: Path):
+    rows = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def write_jsonl(path: Path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def split_fixed(text: str, chunk_size: int, overlap: int):
+    text = (text or "").strip()
+    if not text:
+        return []
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be > 0")
+    if overlap < 0:
+        raise ValueError("overlap must be >= 0")
+    if overlap >= chunk_size:
+        raise ValueError("overlap must be smaller than chunk_size")
+
+    chunks = []
+    step = chunk_size - overlap
+    start = 0
+    while start < len(text):
+        end = min(start + chunk_size, len(text))
+        chunk = text[start:end].strip()
+        if chunk:
+            chunks.append(chunk)
+        if end >= len(text):
+            break
+        start += step
+    return chunks
+
+
+def split_by_paragraph(text: str, chunk_size: int, overlap: int):
+    text = (text or "").strip()
+    if not text:
+        return []
+
+    paragraphs = [p.strip() for p in text.split("\n") if p.strip()]
+    if not paragraphs:
+        return []
+
+    chunks = []
+    current = ""
+
+    for para in paragraphs:
+        if not current:
+            current = para
+            continue
+
+        merged = f"{current}\n{para}"
+        if len(merged) <= chunk_size:
+            current = merged
+        else:
+            chunks.append(current)
+            if overlap > 0 and len(current) > overlap:
+                carry = current[-overlap:].strip()
+                current = f"{carry}\n{para}" if carry else para
+            else:
+                current = para
+
+    if current:
+        chunks.append(current)
+
+    refined = []
+    for chunk in chunks:
+        if len(chunk) <= chunk_size:
+            refined.append(chunk)
+            continue
+        refined.extend(split_fixed(chunk, chunk_size=chunk_size, overlap=overlap))
+    return refined
+
+
+def dedup_rows(rows):
+    seen = set()
+    deduped = []
+
+    for row in rows:
+        key = (row.get("doc_id"), (row.get("text") or "").strip())
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(row)
+    return deduped
+
+
+def build_chunk_base_id(row, fallback_idx: int):
+    #같은 doc_id가 여러 파일에 존재할 수 있기 때문에 chunk_id 중복을 막기 위해 doc_id와 source_file 이름을 함께 사용한다. 
+    doc_id = str(row.get("doc_id", fallback_idx))
+    source_file = str(row.get("source_file", ""))
+    source_stem = Path(source_file).stem if source_file else f"row{fallback_idx}"
+    return f"{doc_id}::{source_stem}"
+
+
+def build_qna_paragraph_chunks(input_jsonl: Path, output_jsonl: Path, chunk_size: int, overlap: int):
+    rows = load_jsonl(input_jsonl)
+    rows = dedup_rows(rows)
+    out_rows = []
+
+    for idx, row in enumerate(rows):
+        text = (row.get("rag_text") or row.get("text") or "").strip()
+        if not text:
+            continue
+
+        chunks = split_by_paragraph(text, chunk_size=chunk_size, overlap=overlap)
+        if not chunks:
+            continue
+
+        base_id = build_chunk_base_id(row, idx)
+        for chunk_index, chunk_text in enumerate(chunks):
+            chunk_row = {
+                **row,
+                "chunk_id": f"{base_id}::{chunk_index}",
+                "chunk_index": chunk_index,
+                "chunk_text": chunk_text,
+                "chunk_strategy": "paragraph",
+                "chunk_size": chunk_size,
+                "chunk_overlap": overlap,
+            }
+            out_rows.append(chunk_row)
+
+    write_jsonl(output_jsonl, out_rows)
+    print(f"QnA chunking 완료 (paragraph): {output_jsonl}")
+    print(f"input_rows={len(rows)}, output_chunks={len(out_rows)}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--input",
+        default=str(OUTPUT_DIR / "qna_rag_documents.jsonl"),
+    )
+    parser.add_argument(
+        "--output",
+        default=str(OUTPUT_DIR / "qna_chunks_paragraph.jsonl"),
+    )
+    parser.add_argument("--chunk-size", type=int, default=1000)
+    parser.add_argument("--overlap", type=int, default=180)
+    args = parser.parse_args()
+
+    build_qna_paragraph_chunks(
+        input_jsonl=Path(args.input),
+        output_jsonl=Path(args.output),
+        chunk_size=args.chunk_size,
+        overlap=args.overlap,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/rag/scripts/build_tl1_chunks.py
+++ b/rag/scripts/build_tl1_chunks.py
@@ -1,34 +1,8 @@
 import argparse
-import json
 from pathlib import Path
 
+from chunk_module import load_jsonl, make_chunk_id_base, write_jsonl
 from preprocess_module import OUTPUT_DIR
-
-
-def load_jsonl(path: Path):
-    rows = []
-    with path.open("r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            rows.append(json.loads(line))
-    return rows
-
-
-def write_jsonl(path: Path, rows):
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
-        for row in rows:
-            f.write(json.dumps(row, ensure_ascii=False) + "\n")
-
-
-def build_chunk_base_id(row, fallback_idx: int):
-    #QnA랑 동일한 ID구조, 파일 간 충돌 방지
-    doc_id = str(row.get("doc_id", fallback_idx))
-    source_file = str(row.get("source_file", ""))
-    source_stem = Path(source_file).stem if source_file else f"row{fallback_idx}"
-    return f"{doc_id}::{source_stem}"
 
 
 def build_tl1_no_split(input_jsonl: Path, output_jsonl: Path):
@@ -40,7 +14,7 @@ def build_tl1_no_split(input_jsonl: Path, output_jsonl: Path):
         if not text:
             continue
 
-        base_id = build_chunk_base_id(row, idx)
+        base_id = make_chunk_id_base(row, idx)
         chunk_row = {
             **row,
             "chunk_id": f"{base_id}::0",

--- a/rag/scripts/build_tl1_chunks.py
+++ b/rag/scripts/build_tl1_chunks.py
@@ -1,0 +1,79 @@
+import argparse
+import json
+from pathlib import Path
+
+from preprocess_module import OUTPUT_DIR
+
+
+def load_jsonl(path: Path):
+    rows = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def write_jsonl(path: Path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def build_chunk_base_id(row, fallback_idx: int):
+    #QnA랑 동일한 ID구조, 파일 간 충돌 방지
+    doc_id = str(row.get("doc_id", fallback_idx))
+    source_file = str(row.get("source_file", ""))
+    source_stem = Path(source_file).stem if source_file else f"row{fallback_idx}"
+    return f"{doc_id}::{source_stem}"
+
+
+def build_tl1_no_split(input_jsonl: Path, output_jsonl: Path):
+    rows = load_jsonl(input_jsonl)
+    out_rows = []
+
+    for idx, row in enumerate(rows):
+        text = (row.get("rag_text") or row.get("text") or "").strip()
+        if not text:
+            continue
+
+        base_id = build_chunk_base_id(row, idx)
+        chunk_row = {
+            **row,
+            "chunk_id": f"{base_id}::0",
+            "chunk_index": 0,
+            "chunk_text": text,
+            "chunk_strategy": "none",
+            "chunk_size": len(text),
+            "chunk_overlap": 0,
+        }
+        out_rows.append(chunk_row)
+
+    write_jsonl(output_jsonl, out_rows)
+    print(f"TL1 chunking 완료 (무분할): {output_jsonl}")
+    print(f"input_rows={len(rows)}, output_chunks={len(out_rows)}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--input",
+        default=str(OUTPUT_DIR / "tl1_rag_documents.jsonl"),
+    )
+    parser.add_argument(
+        "--output",
+        default=str(OUTPUT_DIR / "tl1_chunks_none.jsonl"),
+    )
+    args = parser.parse_args()
+
+    build_tl1_no_split(
+        input_jsonl=Path(args.input),
+        output_jsonl=Path(args.output),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/rag/scripts/check_qna_chunks.py
+++ b/rag/scripts/check_qna_chunks.py
@@ -50,8 +50,6 @@ def main():
         chunk_id = str(row.get("chunk_id", ""))
         chunk_id_counter[chunk_id] += 1
         chunk_strategy_counter[str(row.get("chunk_strategy", ""))] += 1
-
-        chunk_id = str(row.get("chunk_id", ""))
         if "::" in chunk_id:
             # chunk_id format: {doc_id}::{source_stem}::{chunk_index}
             doc_id = chunk_id.rsplit("::", 1)[0]

--- a/rag/scripts/check_qna_chunks.py
+++ b/rag/scripts/check_qna_chunks.py
@@ -1,0 +1,102 @@
+import argparse
+import json
+import statistics
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from preprocess_module import OUTPUT_DIR
+
+
+def load_jsonl(path: Path):
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            yield json.loads(line)
+
+
+def percentile(values, q):
+    if not values:
+        return 0
+    sorted_values = sorted(values)
+    idx = int((q / 100) * (len(sorted_values) - 1))
+    return sorted_values[idx]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--input",
+        default=str(OUTPUT_DIR / "qna_chunks_paragraph.jsonl"),
+    )
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    rows = 0
+    empty_chunk_text = 0
+    lengths = []
+    chunk_id_counter = Counter()
+    chunk_strategy_counter = Counter()
+    doc_to_indices = defaultdict(list)
+
+    for row in load_jsonl(input_path):
+        rows += 1
+        chunk_text = (row.get("chunk_text") or "").strip()
+        if not chunk_text:
+            empty_chunk_text += 1
+        lengths.append(len(chunk_text))
+
+        chunk_id = str(row.get("chunk_id", ""))
+        chunk_id_counter[chunk_id] += 1
+        chunk_strategy_counter[str(row.get("chunk_strategy", ""))] += 1
+
+        chunk_id = str(row.get("chunk_id", ""))
+        if "::" in chunk_id:
+            # chunk_id format: {doc_id}::{source_stem}::{chunk_index}
+            doc_id = chunk_id.rsplit("::", 1)[0]
+        else:
+            doc_id = str(row.get("doc_id", ""))
+        chunk_index = int(row.get("chunk_index", -1))
+        doc_to_indices[doc_id].append(chunk_index)
+
+    duplicate_chunk_id_rows = sum(v - 1 for v in chunk_id_counter.values() if v > 1)
+    non_contiguous_docs = 0
+    chunks_per_doc = []
+    for indices in doc_to_indices.values():
+        sorted_indices = sorted(indices)
+        chunks_per_doc.append(len(sorted_indices))
+        if sorted_indices != list(range(len(sorted_indices))):
+            non_contiguous_docs += 1
+
+    small_ratio = sum(1 for n in lengths if n < 200) / len(lengths) if lengths else 0.0
+    large_ratio = sum(1 for n in lengths if n > 1200) / len(lengths) if lengths else 0.0
+
+    print(f"[QnA Chunk Sanity Check] {input_path}")
+    print(f"rows={rows}")
+    print(f"unique_doc_ids={len(doc_to_indices)}")
+    print(f"empty_chunk_text={empty_chunk_text}")
+    print(f"duplicate_chunk_id_rows={duplicate_chunk_id_rows}")
+    print(f"non_contiguous_docs={non_contiguous_docs}")
+    print(f"chunk_strategies={dict(chunk_strategy_counter)}")
+    print(
+        "chunk_length_stats="
+        f"avg:{round(statistics.mean(lengths), 2) if lengths else 0}, "
+        f"p50:{percentile(lengths, 50)}, "
+        f"p90:{percentile(lengths, 90)}, "
+        f"p95:{percentile(lengths, 95)}, "
+        f"max:{max(lengths) if lengths else 0}"
+    )
+    print(f"small_ratio_lt200={round(small_ratio, 4)}")
+    print(f"large_ratio_gt1200={round(large_ratio, 4)}")
+    print(
+        "chunks_per_doc_stats="
+        f"p50:{percentile(chunks_per_doc, 50)}, "
+        f"p90:{percentile(chunks_per_doc, 90)}, "
+        f"p95:{percentile(chunks_per_doc, 95)}, "
+        f"max:{max(chunks_per_doc) if chunks_per_doc else 0}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/rag/scripts/check_qna_chunks.py
+++ b/rag/scripts/check_qna_chunks.py
@@ -51,7 +51,7 @@ def main():
         chunk_id_counter[chunk_id] += 1
         chunk_strategy_counter[str(row.get("chunk_strategy", ""))] += 1
         if "::" in chunk_id:
-            # chunk_id format: {doc_id}::{source_stem}::{chunk_index}
+            #chunk_id 형식 = {doc_id}::{source}::{chunk_index}
             doc_id = chunk_id.rsplit("::", 1)[0]
         else:
             doc_id = str(row.get("doc_id", ""))

--- a/rag/scripts/check_tl1_chunks.py
+++ b/rag/scripts/check_tl1_chunks.py
@@ -1,0 +1,100 @@
+import argparse
+import json
+import statistics
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from preprocess_module import OUTPUT_DIR
+
+
+def load_jsonl(path: Path):
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            yield json.loads(line)
+
+
+def percentile(values, q):
+    if not values:
+        return 0
+    sorted_values = sorted(values)
+    idx = int((q / 100) * (len(sorted_values) - 1))
+    return sorted_values[idx]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--input",
+        default=str(OUTPUT_DIR / "tl1_chunks_none.jsonl"),
+    )
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    rows = 0
+    empty_chunk_text = 0
+    lengths = []
+    chunk_id_counter = Counter()
+    chunk_strategy_counter = Counter()
+    doc_to_indices = defaultdict(list)
+
+    for row in load_jsonl(input_path):
+        rows += 1
+        chunk_text = (row.get("chunk_text") or "").strip()
+        if not chunk_text:
+            empty_chunk_text += 1
+        lengths.append(len(chunk_text))
+
+        chunk_id = str(row.get("chunk_id", ""))
+        chunk_id_counter[chunk_id] += 1
+        chunk_strategy_counter[str(row.get("chunk_strategy", ""))] += 1
+
+        doc_id = str(row.get("doc_id", ""))
+        chunk_index = int(row.get("chunk_index", -1))
+        doc_to_indices[doc_id].append(chunk_index)
+
+    duplicate_chunk_id_rows = sum(v - 1 for v in chunk_id_counter.values() if v > 1)
+    non_contiguous_docs = 0
+    chunks_per_doc = []
+    for indices in doc_to_indices.values():
+        sorted_indices = sorted(indices)
+        chunks_per_doc.append(len(sorted_indices))
+        if sorted_indices != list(range(len(sorted_indices))):
+            non_contiguous_docs += 1
+
+    small_ratio = sum(1 for n in lengths if n < 200) / len(lengths) if lengths else 0.0
+    large_ratio = sum(1 for n in lengths if n > 1200) / len(lengths) if lengths else 0.0
+
+    print(f"[TL1 Chunk Sanity Check] {input_path}")
+    print(f"rows={rows}")
+    print(f"unique_doc_ids={len(doc_to_indices)}")
+    print(f"empty_chunk_text={empty_chunk_text}")
+    print(f"duplicate_chunk_id_rows={duplicate_chunk_id_rows}")
+    print(f"non_contiguous_docs={non_contiguous_docs}")
+    print(f"chunk_strategies={dict(chunk_strategy_counter)}")
+    print(
+        "chunk_length_stats="
+        f"avg:{round(statistics.mean(lengths), 2) if lengths else 0}, "
+        f"p50:{percentile(lengths, 50)}, "
+        f"p90:{percentile(lengths, 90)}, "
+        f"p95:{percentile(lengths, 95)}, "
+        f"max:{max(lengths) if lengths else 0}"
+    )
+    print(f"small_ratio_lt200={round(small_ratio, 4)}")
+    print(f"large_ratio_gt1200={round(large_ratio, 4)}")
+    print(
+        "chunks_per_doc_stats="
+        f"p50:{percentile(chunks_per_doc, 50)}, "
+        f"p95:{percentile(chunks_per_doc, 95)}, "
+        f"max:{max(chunks_per_doc) if chunks_per_doc else 0}"
+    )
+
+    # TL1 should be 1 document -> 1 chunk in this pipeline.
+    multi_chunk_docs = sum(1 for n in chunks_per_doc if n > 1)
+    print(f"multi_chunk_docs={multi_chunk_docs}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rag/scripts/check_tl1_chunks.py
+++ b/rag/scripts/check_tl1_chunks.py
@@ -51,7 +51,11 @@ def main():
         chunk_id_counter[chunk_id] += 1
         chunk_strategy_counter[str(row.get("chunk_strategy", ""))] += 1
 
-        doc_id = str(row.get("doc_id", ""))
+        if "::" in chunk_id:
+            #chunk_id 형식 = {doc_id}::{source}::{chunk_index}
+            doc_id = chunk_id.rsplit("::", 1)[0]
+        else:
+            doc_id = str(row.get("doc_id", ""))
         chunk_index = int(row.get("chunk_index", -1))
         doc_to_indices[doc_id].append(chunk_index)
 

--- a/rag/scripts/chunk_experiment.py
+++ b/rag/scripts/chunk_experiment.py
@@ -3,86 +3,8 @@ import json
 import statistics
 from pathlib import Path
 
+from chunk_module import chunk_by_paragraph, chunk_fixed, load_jsonl
 from preprocess_module import OUTPUT_DIR
-
-
-def load_jsonl(path: Path):
-    rows = []
-    with path.open("r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            rows.append(json.loads(line))
-    return rows
-
-
-def split_fixed(text: str, chunk_size: int, overlap: int):
-    text = (text or "").strip()
-    if not text:
-        return []
-
-    if chunk_size <= 0:
-        raise ValueError("chunk_size must be > 0")
-    if overlap < 0:
-        raise ValueError("overlap must be >= 0")
-    if overlap >= chunk_size:
-        raise ValueError("overlap must be smaller than chunk_size")
-
-    chunks = []
-    step = chunk_size - overlap
-    start = 0
-    while start < len(text):
-        end = min(start + chunk_size, len(text))
-        chunk = text[start:end].strip()
-        if chunk:
-            chunks.append(chunk)
-        if end >= len(text):
-            break
-        start += step
-    return chunks
-
-
-def split_by_paragraph(text: str, chunk_size: int, overlap: int):
-    text = (text or "").strip()
-    if not text:
-        return []
-
-    paragraphs = [p.strip() for p in text.split("\n") if p.strip()]
-    if not paragraphs:
-        return []
-
-    chunks = []
-    current = ""
-
-    for para in paragraphs:
-        if not current:
-            current = para
-            continue
-
-        merged = f"{current}\n{para}"
-        if len(merged) <= chunk_size:
-            current = merged
-        else:
-            chunks.append(current)
-            if overlap > 0 and len(current) > overlap:
-                carry = current[-overlap:].strip()
-                current = f"{carry}\n{para}" if carry else para
-            else:
-                current = para
-
-    if current:
-        chunks.append(current)
-
-    # 너무 큰 문단 있을 경우
-    refined = []
-    for c in chunks:
-        if len(c) <= chunk_size:
-            refined.append(c)
-            continue
-        refined.extend(split_fixed(c, chunk_size=chunk_size, overlap=overlap))
-    return refined
-
 
 def tokenize_estimate(text: str):
     # 경험적 추정 (글자 수를 2로 나누면 대략적인 토큰 수)
@@ -131,9 +53,9 @@ def build_chunks(rows, strategy: str, chunk_size: int, overlap: int):
     for row in rows:
         text = row.get("rag_text") or row.get("text") or ""
         if strategy == "fixed":
-            chunks = split_fixed(text, chunk_size=chunk_size, overlap=overlap)
+            chunks = chunk_fixed(text, chunk_size=chunk_size, overlap=overlap)
         elif strategy == "paragraph":
-            chunks = split_by_paragraph(text, chunk_size=chunk_size, overlap=overlap)
+            chunks = chunk_by_paragraph(text, chunk_size=chunk_size, overlap=overlap)
         else:
             raise ValueError(f"unsupported strategy: {strategy}")
         all_chunks.extend(chunks)

--- a/rag/scripts/chunk_experiment.py
+++ b/rag/scripts/chunk_experiment.py
@@ -1,0 +1,202 @@
+import argparse
+import json
+import statistics
+from pathlib import Path
+
+from preprocess_module import OUTPUT_DIR
+
+
+def load_jsonl(path: Path):
+    rows = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def split_fixed(text: str, chunk_size: int, overlap: int):
+    text = (text or "").strip()
+    if not text:
+        return []
+
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be > 0")
+    if overlap < 0:
+        raise ValueError("overlap must be >= 0")
+    if overlap >= chunk_size:
+        raise ValueError("overlap must be smaller than chunk_size")
+
+    chunks = []
+    step = chunk_size - overlap
+    start = 0
+    while start < len(text):
+        end = min(start + chunk_size, len(text))
+        chunk = text[start:end].strip()
+        if chunk:
+            chunks.append(chunk)
+        if end >= len(text):
+            break
+        start += step
+    return chunks
+
+
+def split_by_paragraph(text: str, chunk_size: int, overlap: int):
+    text = (text or "").strip()
+    if not text:
+        return []
+
+    paragraphs = [p.strip() for p in text.split("\n") if p.strip()]
+    if not paragraphs:
+        return []
+
+    chunks = []
+    current = ""
+
+    for para in paragraphs:
+        if not current:
+            current = para
+            continue
+
+        merged = f"{current}\n{para}"
+        if len(merged) <= chunk_size:
+            current = merged
+        else:
+            chunks.append(current)
+            if overlap > 0 and len(current) > overlap:
+                carry = current[-overlap:].strip()
+                current = f"{carry}\n{para}" if carry else para
+            else:
+                current = para
+
+    if current:
+        chunks.append(current)
+
+    # 너무 큰 문단 있을 경우
+    refined = []
+    for c in chunks:
+        if len(c) <= chunk_size:
+            refined.append(c)
+            continue
+        refined.extend(split_fixed(c, chunk_size=chunk_size, overlap=overlap))
+    return refined
+
+
+def tokenize_estimate(text: str):
+    # 경험적 추정 (글자 수를 2로 나누면 대략적인 토큰 수)
+    return max(1, len(text) // 2)
+
+
+def evaluate_chunks(chunks):
+    if not chunks:
+        return {
+            "chunk_count": 0,
+            "average_chars": 0,
+            "95p_chars": 0,
+            "average_tokens_estimate": 0,
+            "95p_tokens_estimate": 0,
+            "lessthan_200_ratio": 0.0,
+            "greaterthan_1200_ratio": 0.0,
+        }
+
+    char_lengths = [len(c) for c in chunks]
+    token_lengths = [tokenize_estimate(c) for c in chunks]
+
+    too_small = sum(1 for n in char_lengths if n < 200)
+    too_large = sum(1 for n in char_lengths if n > 1200)
+
+    return {
+        "chunk_count": len(chunks),
+        "average_chars": round(statistics.mean(char_lengths), 2),
+        "95p_chars": percentile(char_lengths, 95),
+        "average_tokens_estimate": round(statistics.mean(token_lengths), 2),
+        "95p_tokens_estimate": percentile(token_lengths, 95),
+        "lessthan_200_ratio": round(too_small / len(chunks), 4),
+        "greaterthan_1200_ratio": round(too_large / len(chunks), 4),
+    }
+
+
+def percentile(values, q):
+    if not values:
+        return 0
+    s = sorted(values)
+    idx = int((q / 100) * (len(s) - 1))
+    return s[idx]
+
+
+def build_chunks(rows, strategy: str, chunk_size: int, overlap: int):
+    all_chunks = []
+    for row in rows:
+        text = row.get("rag_text") or row.get("text") or ""
+        if strategy == "fixed":
+            chunks = split_fixed(text, chunk_size=chunk_size, overlap=overlap)
+        elif strategy == "paragraph":
+            chunks = split_by_paragraph(text, chunk_size=chunk_size, overlap=overlap)
+        else:
+            raise ValueError(f"unsupported strategy: {strategy}")
+        all_chunks.extend(chunks)
+    return all_chunks
+
+
+def run_experiment(input_jsonl: Path, output_report: Path):
+    rows = load_jsonl(input_jsonl)
+    configs = [
+        {"name": "fixed_600_100", "strategy": "fixed", "chunk_size": 600, "overlap": 100},
+        {"name": "fixed_900_150", "strategy": "fixed", "chunk_size": 900, "overlap": 150},
+        {"name": "paragraph_700_120", "strategy": "paragraph", "chunk_size": 700, "overlap": 120},
+        {"name": "paragraph_1000_150", "strategy": "paragraph", "chunk_size": 1000, "overlap": 150},
+    ]
+
+    result_rows = []
+    for cfg in configs:
+        chunks = build_chunks(
+            rows,
+            strategy=cfg["strategy"],
+            chunk_size=cfg["chunk_size"],
+            overlap=cfg["overlap"],
+        )
+        metrics = evaluate_chunks(chunks)
+        result_rows.append({**cfg, **metrics})
+
+    report = {
+        "input_file": str(input_jsonl),
+        "document_count": len(rows),
+        "experiments": result_rows,
+    }
+
+    output_report.parent.mkdir(parents=True, exist_ok=True)
+    with output_report.open("w", encoding="utf-8") as f:
+        json.dump(report, f, ensure_ascii=False, indent=2)
+
+    print(f"chunk 실험 완료: {output_report}")
+    for row in result_rows:
+        print(
+            f"{row['name']}: chunks={row['chunk_count']}, "
+            f"average_chars={row['average_chars']}, 95p_chars={row['95p_chars']}, "
+            f"small_ratio={row['lessthan_200_ratio']}, "
+            f"large_ratio={row['greaterthan_1200_ratio']}"
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--input",
+        default=str(OUTPUT_DIR / "tl1_rag_documents.jsonl"),
+    )
+    parser.add_argument(
+        "--output",
+        default=str(OUTPUT_DIR / "chunk_experiment_report.json"),
+    )
+    args = parser.parse_args()
+
+    run_experiment(
+        input_jsonl=Path(args.input),
+        output_report=Path(args.output),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/rag/scripts/chunk_module.py
+++ b/rag/scripts/chunk_module.py
@@ -1,0 +1,121 @@
+import hashlib
+import json
+import re
+from pathlib import Path
+
+
+def load_jsonl(path: Path):
+    rows = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def write_jsonl(path: Path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def check_chunk_params(chunk_size: int, overlap: int):
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be > 0")
+    if overlap < 0:
+        raise ValueError("overlap must be >= 0")
+    if overlap >= chunk_size:
+        raise ValueError("overlap must be smaller than chunk_size")
+
+
+def _make_overlap_text(text: str, overlap: int):
+    if overlap <= 0:
+        return ""
+    if len(text) <= overlap:
+        return text.strip()
+
+    tail = text[-overlap:]
+
+    sentence_breaks = [m.end() for m in re.finditer(r"[.!?]\s+|\n+", tail)]
+    if sentence_breaks:
+        return tail[sentence_breaks[-1]:].strip()
+
+    ws_idx = max(tail.rfind(" "), tail.rfind("\n"), tail.rfind("\t"))
+    if ws_idx != -1:
+        return tail[ws_idx + 1:].strip()
+
+    return tail.strip()
+
+
+def chunk_fixed(text: str, chunk_size: int, overlap: int):
+    text = (text or "").strip()
+    if not text:
+        return []
+    check_chunk_params(chunk_size=chunk_size, overlap=overlap)
+
+    chunks = []
+    step = chunk_size - overlap
+    start = 0
+    while start < len(text):
+        end = min(start + chunk_size, len(text))
+        chunk = text[start:end].strip()
+        if chunk:
+            chunks.append(chunk)
+        if end >= len(text):
+            break
+        start += step
+    return chunks
+
+
+def chunk_by_paragraph(text: str, chunk_size: int, overlap: int):
+    text = (text or "").strip()
+    if not text:
+        return []
+    check_chunk_params(chunk_size=chunk_size, overlap=overlap)
+
+    paragraphs = [p.strip() for p in text.split("\n") if p.strip()]
+    if not paragraphs:
+        return []
+
+    chunks = []
+    current = ""
+
+    for para in paragraphs:
+        if not current:
+            current = para
+            continue
+
+        merged = f"{current}\n{para}"
+        if len(merged) <= chunk_size:
+            current = merged
+        else:
+            chunks.append(current)
+            carry = _make_overlap_text(current, overlap)
+            current = f"{carry}\n{para}" if carry else para
+
+    if current:
+        chunks.append(current)
+
+    refined = []
+    for chunk in chunks:
+        if len(chunk) <= chunk_size:
+            refined.append(chunk)
+            continue
+        refined.extend(chunk_fixed(chunk, chunk_size=chunk_size, overlap=overlap))
+    return refined
+
+
+def make_chunk_id_base(row, fallback_idx: int):
+    doc_id = str(row.get("doc_id", fallback_idx))
+    source_file = str(row.get("source_file", ""))
+    if not source_file:
+        return f"{doc_id}::row{fallback_idx}"
+
+    source_path = Path(source_file)
+    source_slug = source_path.stem
+    source_key = str(row.get("source_path") or source_file)
+    source_hash = hashlib.sha1(source_key.encode("utf-8")).hexdigest()[:8]
+    return f"{doc_id}::{source_slug}_{source_hash}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ asyncpg==0.31.0
 boto3==1.42.95
 botocore==1.42.95
 click==8.3.2
+colorama==0.4.6
 fastapi==0.135.3
 greenlet==3.2.4
 h11==0.16.0
@@ -27,5 +28,6 @@ SQLAlchemy==2.0.49
 starlette==1.0.0
 typing-inspection==0.4.2
 typing_extensions==4.15.0
+tzdata==2026.1
 urllib3==2.6.3
 uvicorn==0.44.0


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #13 

## ✨ 작업 개요
- TL1 및 QnA 데이터에 대한 RAG chunking 파이프라인을 구현했습니다.
- TL1 데이터는 무분할(1문서 = 1청크) 방식으로 처리하였고,
- QnA 데이터는 문단 기반(paragraph) chunking을 적용했습니다.
- chunk_size=1000, overlap=180 기준으로 분할하여 문맥 단위 유지 및 길이 최적화를 진행했습니다.
- chunk_id를 doc_id + source_file + chunk_index 구조로 변경하여 ID 충돌 가능성을 제거했습니다.
- chunk 결과 검증을 위한 sanity check 및 통계 확인 스크립트를 추가했습니다. (AI 코드)
### 📁 추가된 파일
- rag/scripts/build_qna_chunks.py
- rag/scripts/build_tl1_chunks.py
- rag/scripts/check_qna_chunks.py
- rag/scripts/check_tl1_chunks.py
- rag/scripts/chunk_experiment.py
### 📄 변경된 파일
- requirements.txt (pip freeze로 갱신)
### 📦 생성되는 결과 파일 (실행 시)
- rag/output/qna_chunks_paragraph.jsonl
- rag/output/tl1_chunks_none.jsonl

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [ ] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
- [x] requirements.txt 최신 상태로 freeze 하였나요?

## 📷 이미지 첨부 (선택)
<img width="2399" height="589" alt="스크린샷 2026-04-28 020415" src="https://github.com/user-attachments/assets/3b885a3d-9533-4822-80e5-2afffbd188be" />
<img width="2381" height="536" alt="스크린샷 2026-04-28 020349" src="https://github.com/user-attachments/assets/acf58686-9119-4345-b219-7fed0c569157" />

## 🧐 집중 리뷰 요청
- QnA paragraph chunking 전략이 적절한지 (chunk_size=1000, overlap=180)
- chunk_id 생성 방식 (doc_id + source_file + chunk_index)이 적절한지
- 향후 embedding 및 vector DB 적재를 고려했을 때 구조적으로 문제 없는지
- .gitignore 잘 설정되어 있는지 확인 부탁드립니다!