### PR TITLE
[FEAT] LlamaIndex 기반 pgvector 임베딩 및 검색 파이프라인 구축

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -65,6 +65,11 @@ class Settings(BaseSettings):
         default="simple",
         alias="VECTOR_TEXT_SEARCH_CONFIG",
     )
+    # True면 lifespan에서 Gemini embed API로 차원 검증
+    vector_dim_check: bool = Field(
+        default=False,
+        alias="VECTOR_DIM_CHECK",
+    )
 
     @field_validator("redis_local_port", "redis_aws_port", "redis_aws_db", mode="before")
     @classmethod

--- a/app/services/VectorStoreService.py
+++ b/app/services/VectorStoreService.py
@@ -72,7 +72,7 @@ class VectorStoreService:
 
     def _resolve_table_name(self, *, domain: str | None, table_name: str | None) -> str:
         if table_name:
-            return table_name
+            return self._normalize_domain(table_name)
         if domain is None or not domain.strip():
             return self._default_table_name
         domain_config = self._resolve_domain_config(domain)
@@ -158,12 +158,13 @@ class VectorStoreService:
         for domain, cfg in self._domain_configs.items():
             checks.append((domain.value, cfg.embedding_model, cfg.embed_dim))
 
-        unique_checks: dict[tuple[str, int], tuple[str, int]] = {}
+        by_model_dim: dict[tuple[str, int], list[str]] = {}
         for scope, model_name, expected_dim in checks:
-            unique_checks[(model_name, expected_dim)] = (scope, expected_dim)
+            key = (model_name, expected_dim)
+            by_model_dim.setdefault(key, []).append(scope)
 
         results: list[dict[str, Any]] = []
-        for model_name, expected_dim in unique_checks:
+        for (model_name, expected_dim), scopes in by_model_dim.items():
             actual_dim = await run_in_threadpool(
                 self._embedding_length,
                 model_name=model_name,
@@ -175,6 +176,7 @@ class VectorStoreService:
                     "expected_dim": expected_dim,
                     "actual_dim": actual_dim,
                     "matched": actual_dim == expected_dim,
+                    "scopes": scopes,
                 }
             )
         return results
@@ -231,4 +233,4 @@ class VectorStoreService:
             filters=filters,
             vector_store_query_mode=vector_store_query_mode,
         )
-        return await run_in_threadpool(retriever.retrieve, query)
+        return await retriever.aretrieve(query)

--- a/rag/engin/LlamaIndex.py
+++ b/rag/engin/LlamaIndex.py
@@ -1,6 +1,0 @@
-from app.core.config import settings
-from llama_index.core import SimpleDirectoryReader, StorageContext
-from llama_index.core import VectorStoreIndex
-from llama_index.vector_stores.postgres import PGVectorStore
-import textwrap
-

--- a/rag/scripts/embed_chunks_gemini.py
+++ b/rag/scripts/embed_chunks_gemini.py
@@ -161,13 +161,18 @@ def normalize_chunk(
 def build_qna_embedding_text(
     row: Dict,
     skip_line_prefixes: Optional[tuple[str, ...]] = None,
+    *,
+    normalized_chunk_body: Optional[str] = None,
 ) -> str:
     # TL1과 달리 QnA row의 text/rag_text에는 보통 제목 줄이 있어 split_title_body가 유효함.
     chunk_source = str(row.get("chunk_text") or "").strip()
     full_title, _ = split_title_body(
         str(row.get("rag_text") or row.get("text") or "").strip()
     )
-    body = normalize_chunk(chunk_source, skip_line_prefixes=skip_line_prefixes)
+    if normalized_chunk_body is not None:
+        body = normalized_chunk_body
+    else:
+        body = normalize_chunk(chunk_source, skip_line_prefixes=skip_line_prefixes)
     if full_title and full_title != "제목 없음":
         return f"[제목] {full_title}\n[본문] {body}"
     return body
@@ -187,10 +192,18 @@ def build_tl1_embedding_text(
 def build_embedding_text(
     row: Dict,
     skip_line_prefixes: Optional[tuple[str, ...]] = None,
+    *,
+    normalized_chunk_body: Optional[str] = None,
 ) -> str:
     row_type = chunk_data_type(row)
     if row_type == "qna":
-        return build_qna_embedding_text(row, skip_line_prefixes=skip_line_prefixes)
+        return build_qna_embedding_text(
+            row,
+            skip_line_prefixes=skip_line_prefixes,
+            normalized_chunk_body=normalized_chunk_body,
+        )
+    if normalized_chunk_body is not None:
+        return normalized_chunk_body
     return build_tl1_embedding_text(row, skip_line_prefixes=skip_line_prefixes)
 
 
@@ -293,7 +306,11 @@ def build_embedding_rows(
         if not body:
             continue
 
-        document_text = build_embedding_text(row, skip_line_prefixes=skip_line_prefixes)
+        document_text = build_embedding_text(
+            row,
+            skip_line_prefixes=skip_line_prefixes,
+            normalized_chunk_body=body,
+        )
         chunk_id = str(row.get("chunk_id") or f"row::{idx}")
         work.append(
             {

--- a/rag/scripts/insert_chunks_to_vector.py
+++ b/rag/scripts/insert_chunks_to_vector.py
@@ -8,6 +8,7 @@ import httpx
 from llama_index.core.schema import TextNode
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
+# python -m rag.scripts.insert_chunks_to_vector 형태 실행 기준
 from app.core.config import settings
 from app.services.VectorStoreService import VectorStoreService
 from app.services.vector_domains import DomainVectorConfig, VectorDomain
@@ -17,6 +18,11 @@ from rag.scripts.chunk_module import load_jsonl
 DEFAULT_BATCH_SIZE = 50
 
 def build_service() -> VectorStoreService:
+    api_key_secret = settings.gemini_api_key
+    if api_key_secret is None:
+        raise RuntimeError(
+            "GEMINI_API_KEY가 없습니다. .env 또는 환경 변수 GEMINI_API_KEY를 설정한 뒤 다시 실행하세요."
+        )
     domain_configs = {
         VectorDomain.COMPLAINT: DomainVectorConfig(
             table_name="complaint",
@@ -28,7 +34,7 @@ def build_service() -> VectorStoreService:
     return VectorStoreService(
         database_url=settings.sync_database_url,
         async_database_url=settings.async_database_url,
-        api_key=settings.gemini_api_key.get_secret_value(),
+        api_key=api_key_secret.get_secret_value(),
         table_name=settings.vector_table_name,
         default_embedding_model=settings.gemini_embedding_model,
         default_embed_dim=settings.vector_embed_dim,


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #25 

## ✨ 작업 개요
- LlamaIndex + pgvector 기반 벡터 검색 구조를 구축하고,
- Gemini embedding 모델을 사용한 실제 임베딩 및 검색 파이프라인을 구현했습니다.
- VectorStoreService 구현
- Gemini embedding 연동
- output_dimensionality 차원 검증 추가
- pgvector vector(1536) 검증
- MetadataFilters 기반 검색 구조 구현
- TextNode metadata 저장 구조 구성
- vector-test API 추가
- chunk jsonl -> TextNode -> pgvector 적재 스크립트 구현
- 실제 QnA chunk 100건 임베딩 및 검색 테스트 완료

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
<img width="2711" height="464" alt="스크린샷 2026-05-06 165206" src="https://github.com/user-attachments/assets/d9d0cfe2-9a23-49e3-9caf-9e533837d7af" />

<img width="2724" height="1240" alt="스크린샷 2026-05-06 165748" src="https://github.com/user-attachments/assets/14e321d6-b895-4b0d-9791-f278125a8081" />

## 🧐 집중 리뷰 요청
- MetadataFilters 구조 및 batch insert 처리 방식 위주로 확인 부탁드립니다.