### PR TITLE
[BUG] QnA/TL1 청크 텍스트 정규화 및 공통 normalize 로직 적용

### DIFF
--- a/app/utils/chunk_node_metadata.py
+++ b/app/utils/chunk_node_metadata.py
@@ -1,7 +1,7 @@
 """
 청크 JSONL 행 -> 벡터 DB / MetadataFilters용 메타데이터.
 메타데이터 만드는 공통 함수 파일이다.
-여기만 고치면 두 경로가 같이 바뀐다. (JSONL 실험 스크립트(embed_chunks_gemini)와 LlamaIndex insert_nodes 경로)
+여기만 고치면 청크 적재 경로(LlamaIndex insert_nodes 등)의 메타데이터가 함께 바뀐다.
 """
 
 from __future__ import annotations
@@ -11,6 +11,8 @@ from typing import Any, Mapping
 
 from llama_index.core.schema import TextNode
 
+# TL1(preprocess_tl1): category/subcategory/predication/department — 텍스트의 [민원 …] 라벨줄은
+# chunk_text_normalize 에서 제거하고, 필터용 값은 여기 메타로만 둔다.
 _OPTIONAL_FILTER_METADATA_KEYS = (
     "domain",
     "region",

--- a/app/utils/chunk_text_normalize.py
+++ b/app/utils/chunk_text_normalize.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+# 줄 시작이 이 접두어이면 제외 (None이면 이 기본값 사용)
+# TL1: [민원 …] 줄은 임베딩 텍스트에서만 제거. 분류·부서 값은 JSONL 행의
+# category, subcategory, predication, department → build_chunk_metadata 로 유지.
+DEFAULT_NORMALIZE_SKIP_PREFIXES: tuple[str, ...] = (
+    "[출처 기관]",
+    "[상담 분류]",
+    "[상담 일자]",
+    "[상담 내용]",
+    "[민원 대분류]",
+    "[민원 소분류]",
+    "[민원 유형]",
+    "[담당 부서]",
+    "[민원 내용]",
+)
+
+# 이 줄에서 잘리면 해당 줄과 이후 전부 제거
+DEFAULT_FOOTER_LINE_PREFIXES: tuple[str, ...] = (
+    "끝.",
+    "[본 회신내용",
+)
+
+# 행 전체를 버리는 QnA 답변 서식용 섹션 제목 (□ 질의 요지 등)
+DEFAULT_QNA_SECTION_HEADER_LINES: frozenset[str] = frozenset(
+    {
+        "□ 질의 요지",
+        "□질의 요지",
+        "□ 답변 내용",
+        "□답변 내용",
+    }
+)
+
+# 행 전체가 일치할 때만 제거 (고정 인사말 — 패턴이 확실한 문장만 추가)
+DEFAULT_QNA_GREETING_EXACT_LINES: frozenset[str] = frozenset(
+    {
+        "안녕하십니까? 평소 국토 교통행정에 관심과 애정을 가져 주신 점 깊이 감사드리며, 선생님께서 질의하신 사항에 대하여 아래와 같이 답변드립니다.",
+    }
+)
+
+_QA_LINE_PREFIX_RE = re.compile(r"^[QqAa]\s*:\s*")
+
+
+def _strip_leading_bullet_marks(line: str) -> str:
+    """줄 선두의 □ 또는 ㅇ 표기만 제거(연속 시 반복). 본문은 유지."""
+    s = line
+    while s:
+        if s.startswith("□"):
+            s = s[1:].lstrip()
+            continue
+        if s.startswith("ㅇ"):
+            s = s[1:].lstrip()
+            continue
+        break
+    return s
+
+
+def load_skip_line_prefixes(path: Path) -> tuple[str, ...]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"normalize 설정은 JSON 객체여야 함: {path}")
+    raw = data.get("skip_line_prefixes")
+    if raw is None:
+        raw = data.get("skip_prefixes")
+    if raw is None:
+        raise ValueError(
+            f"normalize 설정에 skip_line_prefixes 또는 skip_prefixes 배열이 필요함: {path}"
+        )
+    if not isinstance(raw, list):
+        raise ValueError(f"skip_line_prefixes는 문자열 배열이어야 함: {path}")
+    return tuple(str(x) for x in raw)
+
+
+def normalize_chunk(
+    chunk_text: str,
+    skip_line_prefixes: Optional[tuple[str, ...]] = None,
+    footer_line_prefixes: Optional[tuple[str, ...]] = None,
+    *,
+    qna_section_headers: Optional[frozenset[str]] = None,
+    qna_greeting_exact_lines: Optional[frozenset[str]] = None,
+) -> str:
+    """QnA/TL1 청크 공통: 메타 줄 제거 + 푸터(끝./회신 유의) 이후 절단
+
+    QnA 본문: Q:/A: 라벨·□/ㅇ 불릿 접두 제거, 질의/답변 섹션 제목 줄 삭제,
+    고정 인사말(전체 행 일치)만 삭제.
+
+    footer_line_prefixes가 ()이면 푸터 절단만 끈다. None이면 기본 푸터 규칙 사용
+    """
+    raw = chunk_text.strip()
+    if not raw:
+        return ""
+
+    prefixes = (
+        DEFAULT_NORMALIZE_SKIP_PREFIXES
+        if skip_line_prefixes is None
+        else skip_line_prefixes
+    )
+    if footer_line_prefixes is None:
+        footers = DEFAULT_FOOTER_LINE_PREFIXES
+    else:
+        footers = footer_line_prefixes
+
+    section_drop = (
+        DEFAULT_QNA_SECTION_HEADER_LINES
+        if qna_section_headers is None
+        else qna_section_headers
+    )
+    greeting_drop = (
+        DEFAULT_QNA_GREETING_EXACT_LINES
+        if qna_greeting_exact_lines is None
+        else qna_greeting_exact_lines
+    )
+
+    cleaned_lines: list[str] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if footers:
+            if stripped == "끝":
+                break
+            if stripped.startswith("끝."):
+                break
+            if stripped.startswith(footers):
+                break
+        if prefixes and stripped.startswith(prefixes):
+            continue
+        if stripped.startswith("제목 :"):
+            continue
+        if stripped in section_drop:
+            continue
+
+        after_qa = _QA_LINE_PREFIX_RE.sub("", stripped, count=1)
+        if after_qa in greeting_drop:
+            continue
+
+        after_bullets = _strip_leading_bullet_marks(after_qa)
+        if not after_bullets:
+            continue
+
+        cleaned_lines.append(after_bullets)
+
+    return "\n".join(cleaned_lines).strip()

--- a/app/utils/chunk_text_normalize.py
+++ b/app/utils/chunk_text_normalize.py
@@ -6,8 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 # 줄 시작이 이 접두어이면 제외 (None이면 이 기본값 사용)
-# TL1: [민원 …] 줄은 임베딩 텍스트에서만 제거. 분류·부서 값은 JSONL 행의
-# category, subcategory, predication, department → build_chunk_metadata 로 유지.
+# TL1: [민원 …] 줄은 임베딩 텍스트에서만 제거. 부서 값은 JSONL 행의 category, subcategory.. → build_chunk_metadata 로
 DEFAULT_NORMALIZE_SKIP_PREFIXES: tuple[str, ...] = (
     "[출처 기관]",
     "[상담 분류]",
@@ -26,7 +25,7 @@ DEFAULT_FOOTER_LINE_PREFIXES: tuple[str, ...] = (
     "[본 회신내용",
 )
 
-# 행 전체를 버리는 QnA 답변 서식용 섹션 제목 (□ 질의 요지 등)
+# 행 전체를 버리는 QnA 답변 서식용 섹션 제목 (질의 요지 등)
 DEFAULT_QNA_SECTION_HEADER_LINES: frozenset[str] = frozenset(
     {
         "□ 질의 요지",
@@ -44,20 +43,12 @@ DEFAULT_QNA_GREETING_EXACT_LINES: frozenset[str] = frozenset(
 )
 
 _QA_LINE_PREFIX_RE = re.compile(r"^[QqAa]\s*:\s*")
+_STRIP_LEADING_BULLETS_RE = re.compile(r"^[□ㅇ\s]+")
 
 
 def _strip_leading_bullet_marks(line: str) -> str:
-    """줄 선두의 □ 또는 ㅇ 표기만 제거(연속 시 반복). 본문은 유지."""
-    s = line
-    while s:
-        if s.startswith("□"):
-            s = s[1:].lstrip()
-            continue
-        if s.startswith("ㅇ"):
-            s = s[1:].lstrip()
-            continue
-        break
-    return s
+    #줄 선두의 문자 및 인접 공백만 제거. 본문은 유지
+    return _STRIP_LEADING_BULLETS_RE.sub("", line)
 
 
 def load_skip_line_prefixes(path: Path) -> tuple[str, ...]:
@@ -84,12 +75,14 @@ def normalize_chunk(
     qna_section_headers: Optional[frozenset[str]] = None,
     qna_greeting_exact_lines: Optional[frozenset[str]] = None,
 ) -> str:
-    """QnA/TL1 청크 공통: 메타 줄 제거 + 푸터(끝./회신 유의) 이후 절단
+    """QnA/TL1 청크 공통: 메타 줄 제거 + 푸터 이후 절단
 
-    QnA 본문: Q:/A: 라벨·□/ㅇ 불릿 접두 제거, 질의/답변 섹션 제목 줄 삭제,
+    QnA 본문: Q:/A: 라벨 불릿 접두 제거, 질의/답변 섹션 제목 줄 삭제,
     고정 인사말(전체 행 일치)만 삭제.
 
-    footer_line_prefixes가 ()이면 푸터 절단만 끈다. None이면 기본 푸터 규칙 사용
+    footer_line_prefixes: None이면 DEFAULT_FOOTER_LINE_PREFIXES에 더해, 행 전체가
+    끝인 경우만 추가로 절단(끝나 같은 본문과 구분). ()이면 푸터 절단 전부 끔
+    그 외 비어 있지 않은 튜플이면 그 접두어들에 대한 startswith만 절단 기준으로
     """
     raw = chunk_text.strip()
     if not raw:
@@ -100,7 +93,8 @@ def normalize_chunk(
         if skip_line_prefixes is None
         else skip_line_prefixes
     )
-    if footer_line_prefixes is None:
+    default_footer = footer_line_prefixes is None
+    if default_footer:
         footers = DEFAULT_FOOTER_LINE_PREFIXES
     else:
         footers = footer_line_prefixes
@@ -122,9 +116,7 @@ def normalize_chunk(
         if not stripped:
             continue
         if footers:
-            if stripped == "끝":
-                break
-            if stripped.startswith("끝."):
+            if default_footer and stripped == "끝":
                 break
             if stripped.startswith(footers):
                 break
@@ -132,15 +124,13 @@ def normalize_chunk(
             continue
         if stripped.startswith("제목 :"):
             continue
-        if stripped in section_drop:
-            continue
 
         after_qa = _QA_LINE_PREFIX_RE.sub("", stripped, count=1)
-        if after_qa in greeting_drop:
+        if stripped in section_drop or after_qa in section_drop:
             continue
 
         after_bullets = _strip_leading_bullet_marks(after_qa)
-        if not after_bullets:
+        if not after_bullets or after_bullets in greeting_drop:
             continue
 
         cleaned_lines.append(after_bullets)

--- a/rag/scripts/embed_chunks_gemini.py
+++ b/rag/scripts/embed_chunks_gemini.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import json
 import os
 import sys
 from datetime import datetime, timezone
@@ -25,6 +24,7 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.append(str(_REPO_ROOT))
 
 from app.utils.chunk_node_metadata import build_chunk_metadata, chunk_data_type
+from app.utils.chunk_text_normalize import load_skip_line_prefixes, normalize_chunk
 
 from chunk_module import load_jsonl, write_jsonl
 from preprocess_module import OUTPUT_DIR
@@ -36,37 +36,12 @@ DEFAULT_MODEL = "gemini-embedding-2"
 DEFAULT_OUTPUT_DIMENSIONALITY = 1536
 # embed_content에 문자열 리스트를 넘기면 한 번의 요청으로 배치 임베딩 (RTT 감소)
 DEFAULT_EMBED_BATCH_SIZE = 100
-
 DEFAULT_EMBED_RETRY_ATTEMPTS = 8
 DEFAULT_EMBED_RETRY_WAIT_MIN_S = 2
 DEFAULT_EMBED_RETRY_WAIT_MAX_S = 120
 
-# normalize_chunk: 줄 시작이 이 접두어 중 하나면 제외 (None이면 이 기본값 사용)
-DEFAULT_NORMALIZE_SKIP_PREFIXES: tuple[str, ...] = (
-    "[출처 기관]",
-    "[상담 분류]",
-    "[상담 일자]",
-    "[상담 내용]",
-)
 
-
-def load_skip_line_prefixes(path: Path) -> tuple[str, ...]:
-    data = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(data, dict):
-        raise ValueError(f"normalize 설정은 JSON 객체여야 함: {path}")
-    raw = data.get("skip_line_prefixes")
-    if raw is None:
-        raw = data.get("skip_prefixes")
-    if raw is None:
-        raise ValueError(
-            f"normalize 설정에 skip_line_prefixes 또는 skip_prefixes 배열이 필요함: {path}"
-        )
-    if not isinstance(raw, list):
-        raise ValueError(f"skip_line_prefixes는 문자열 배열이어야 함: {path}")
-    return tuple(str(x) for x in raw)
-
-
-def is_retryable_error(exc: BaseException) -> bool:
+def _embedding_error_is_transient(exc: BaseException) -> bool:
     from google.genai import errors as genai_errors
 
     if isinstance(exc, genai_errors.ServerError):
@@ -94,7 +69,7 @@ EMBED_API_RETRY = Retrying(
         min=DEFAULT_EMBED_RETRY_WAIT_MIN_S,
         max=DEFAULT_EMBED_RETRY_WAIT_MAX_S,
     ),
-    retry=retry_if_exception(is_retryable_error),
+    retry=retry_if_exception(_embedding_error_is_transient),
     reraise=True,
 )
 
@@ -106,9 +81,8 @@ def now_utc() -> str:
 def sha1(text: str) -> str:
     return hashlib.sha1(text.encode("utf-8")).hexdigest()
 
-
 def gemini_model_id(model: str) -> str:
-    #API,embedding_id용 모델 id (models/ 접두어 제거).
+    #embedding_id용 모델 id (models/ 접두어 제거)
     m = model.strip()
     return m[len("models/") :] if m.startswith("models/") else m
 
@@ -129,45 +103,26 @@ def split_title_body(text: str) -> tuple[str, str]:
     return "제목 없음", raw
 
 
-def normalize_chunk(
-    chunk_text: str,
-    skip_line_prefixes: Optional[tuple[str, ...]] = None,
-) -> str:
-    raw = chunk_text.strip()
-    if not raw:
-        return ""
-
-    lines = raw.splitlines()
-    cleaned_lines = []
-    prefixes = (
-        DEFAULT_NORMALIZE_SKIP_PREFIXES
-        if skip_line_prefixes is None
-        else skip_line_prefixes
-    )
-
-    for line in lines:
-        stripped = line.strip()
-        if not stripped:
-            continue
-        if prefixes and stripped.startswith(prefixes):
-            continue
-        if stripped.startswith("제목 :"):
-            continue
-        cleaned_lines.append(stripped)
-
-    return "\n".join(cleaned_lines).strip()
-
-
 def build_qna_embedding_text(
     row: Dict,
     skip_line_prefixes: Optional[tuple[str, ...]] = None,
+    footer_line_prefixes: Optional[tuple[str, ...]] = None,
+    *,
+    normalized_chunk_body: Optional[str] = None,
 ) -> str:
     # TL1과 달리 QnA row의 text/rag_text에는 보통 제목 줄이 있어 split_title_body가 유효함.
     chunk_source = str(row.get("chunk_text") or "").strip()
     full_title, _ = split_title_body(
         str(row.get("rag_text") or row.get("text") or "").strip()
     )
-    body = normalize_chunk(chunk_source, skip_line_prefixes=skip_line_prefixes)
+    if normalized_chunk_body is not None:
+        body = normalized_chunk_body
+    else:
+        body = normalize_chunk(
+            chunk_source,
+            skip_line_prefixes=skip_line_prefixes,
+            footer_line_prefixes=footer_line_prefixes,
+        )
     if full_title and full_title != "제목 없음":
         return f"[제목] {full_title}\n[본문] {body}"
     return body
@@ -176,22 +131,40 @@ def build_qna_embedding_text(
 def build_tl1_embedding_text(
     row: Dict,
     skip_line_prefixes: Optional[tuple[str, ...]] = None,
+    footer_line_prefixes: Optional[tuple[str, ...]] = None,
 ) -> str:
-    # TL1: text/rag_text에 "제목 :" 형식이 없어 QnA처럼 제목 슬롯을 두면 [제목] 제목 없음만 붙음, 본문만 임베딩.
     chunk_source = str(
         row.get("chunk_text") or row.get("rag_text") or row.get("text") or ""
     ).strip()
-    return normalize_chunk(chunk_source, skip_line_prefixes=skip_line_prefixes)
+    return normalize_chunk(
+        chunk_source,
+        skip_line_prefixes=skip_line_prefixes,
+        footer_line_prefixes=footer_line_prefixes,
+    )
 
 
 def build_embedding_text(
     row: Dict,
     skip_line_prefixes: Optional[tuple[str, ...]] = None,
+    footer_line_prefixes: Optional[tuple[str, ...]] = None,
+    *,
+    normalized_chunk_body: Optional[str] = None,
 ) -> str:
     row_type = chunk_data_type(row)
     if row_type == "qna":
-        return build_qna_embedding_text(row, skip_line_prefixes=skip_line_prefixes)
-    return build_tl1_embedding_text(row, skip_line_prefixes=skip_line_prefixes)
+        return build_qna_embedding_text(
+            row,
+            skip_line_prefixes=skip_line_prefixes,
+            footer_line_prefixes=footer_line_prefixes,
+            normalized_chunk_body=normalized_chunk_body,
+        )
+    if normalized_chunk_body is not None:
+        return normalized_chunk_body
+    return build_tl1_embedding_text(
+        row,
+        skip_line_prefixes=skip_line_prefixes,
+        footer_line_prefixes=footer_line_prefixes,
+    )
 
 
 def _mock_embedding_vector(text: str, output_dimensionality: Optional[int]) -> List[float]:
@@ -275,6 +248,7 @@ def build_embedding_rows(
     client: Optional[genai.Client] = None,
     batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
     skip_line_prefixes: Optional[tuple[str, ...]] = None,
+    footer_line_prefixes: Optional[tuple[str, ...]] = None,
 ) -> List[Dict]:
     work: List[Dict] = []
 
@@ -289,11 +263,20 @@ def build_embedding_rows(
             ).strip()
         else:
             raw_for_normalize = str(row.get("chunk_text") or "").strip()
-        body = normalize_chunk(raw_for_normalize, skip_line_prefixes=skip_line_prefixes)
+        body = normalize_chunk(
+            raw_for_normalize,
+            skip_line_prefixes=skip_line_prefixes,
+            footer_line_prefixes=footer_line_prefixes,
+        )
         if not body:
             continue
 
-        document_text = build_embedding_text(row, skip_line_prefixes=skip_line_prefixes)
+        document_text = build_embedding_text(
+            row,
+            skip_line_prefixes=skip_line_prefixes,
+            footer_line_prefixes=footer_line_prefixes,
+            normalized_chunk_body=body,
+        )
         chunk_id = str(row.get("chunk_id") or f"row::{idx}")
         work.append(
             {
@@ -308,8 +291,9 @@ def build_embedding_rows(
     if gemini_model_id(model) == "gemini-embedding-2" and not mock:
         if batch_size != 1:
             print(
-                "gemini-embedding-2는 embed_content 다중 텍스트 시 "
-                f"응답 임베딩이 1건만 와 batch_size를 {batch_size} → 1로 조정합니다.",
+                "gemini-embedding-2는 embed_content에서 다중 텍스트 입력 시 "
+                "임베딩을 1건만 반환하므로 batch_size를 "
+                f"{batch_size} → 1로 조정합니다.",
                 flush=True,
             )
         batch_size = 1
@@ -384,7 +368,7 @@ def main():
         type=int,
         default=None,
         metavar="N",
-        help="임베딩할 최대 청크 수 (미지정 시 전체). 테스트 시에만 지정 권장",
+        help="임베딩할 최대 청크 수. 샘플/테스트 시에만 지정 권장",
     )
     parser.add_argument(
         "--mock",
@@ -414,7 +398,12 @@ def main():
         action="append",
         default=None,
         metavar="PREFIX",
-        help="normalize_chunk에서 제거할 줄 접두어. 지정 시 기본 접두어 대신 이 목록만 사용",
+        help="normalize_chunk에서 제거할 줄 접두어 (여러 번 지정 가능). 지정 시 기본 접두어 대신 이 목록만 사용",
+    )
+    parser.add_argument(
+        "--no-footer-strip",
+        action="store_true",
+        help="끝./[본 회신… 푸터 절단 비활성화",
     )
     args = parser.parse_args()
     if args.log_every < 0:
@@ -432,6 +421,8 @@ def main():
         skip_line_prefixes = load_skip_line_prefixes(args.normalize_config)
     elif args.skip_line_prefix is not None:
         skip_line_prefixes = tuple(args.skip_line_prefix)
+
+    footer_line_prefixes: Optional[tuple[str, ...]] = () if args.no_footer_strip else None
 
     client = None
     if not args.mock:
@@ -460,6 +451,7 @@ def main():
         client=client,
         batch_size=args.batch_size,
         skip_line_prefixes=skip_line_prefixes,
+        footer_line_prefixes=footer_line_prefixes,
     )
     write_jsonl(output_path, out_rows)
     print(f"[done] embedded={len(out_rows)} output={output_path}")

--- a/rag/scripts/insert_chunks_to_vector.py
+++ b/rag/scripts/insert_chunks_to_vector.py
@@ -12,11 +12,18 @@ from app.core.config import settings
 from app.services.VectorStoreService import VectorStoreService
 from app.services.vector_domains import DomainVectorConfig, VectorDomain
 from app.utils.chunk_node_metadata import build_chunk_metadata
+from app.utils.chunk_text_normalize import load_skip_line_prefixes, normalize_chunk
 from rag.scripts.chunk_module import load_jsonl
 
 DEFAULT_BATCH_SIZE = 50
 
+
 def build_service() -> VectorStoreService:
+    api_key_secret = settings.gemini_api_key
+    if api_key_secret is None:
+        raise RuntimeError(
+            "GEMINI_API_KEY가 없습니다. .env 또는 환경 변수 GEMINI_API_KEY를 설정한 뒤 다시 실행하세요."
+        )
     domain_configs = {
         VectorDomain.COMPLAINT: DomainVectorConfig(
             table_name="complaint",
@@ -28,7 +35,7 @@ def build_service() -> VectorStoreService:
     return VectorStoreService(
         database_url=settings.sync_database_url,
         async_database_url=settings.async_database_url,
-        api_key=settings.gemini_api_key.get_secret_value(),
+        api_key=api_key_secret.get_secret_value(),
         table_name=settings.vector_table_name,
         default_embedding_model=settings.gemini_embedding_model,
         default_embed_dim=settings.vector_embed_dim,
@@ -37,16 +44,34 @@ def build_service() -> VectorStoreService:
         text_search_config=settings.vector_text_search_config,
     )
 
-def row_to_node(row: dict) -> TextNode:
-    text = (row.get("chunk_text") or row.get("text") or "").strip()
-    if not text:
+
+def row_to_node(
+    row: dict,
+    *,
+    skip_line_prefixes: tuple[str, ...] | None = None,
+    footer_line_prefixes: tuple[str, ...] | None = None,
+    raw_text: bool = False,
+) -> TextNode:
+    raw = (row.get("chunk_text") or row.get("text") or "").strip()
+    if not raw:
         raise ValueError("empty text")
+    if raw_text:
+        text = raw
+    else:
+        text = normalize_chunk(
+            raw,
+            skip_line_prefixes=skip_line_prefixes,
+            footer_line_prefixes=footer_line_prefixes,
+        )
+    if not text:
+        raise ValueError("empty text after normalize")
     chunk_id = str(row.get("chunk_id") or "")
     return TextNode(
         text=text,
         id_=chunk_id,
         metadata=build_chunk_metadata(row),
     )
+
 
 @retry(
     retry=retry_if_exception_type((httpx.ConnectError, httpx.ReadTimeout, httpx.WriteError, TimeoutError)),
@@ -69,10 +94,34 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--limit", type=int, default=None)
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
     parser.add_argument("--start-offset", type=int, default=0)
+    parser.add_argument(
+        "--normalize-config",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="JSON: skip_line_prefixes(또는 skip_prefixes) 배열",
+    )
+    parser.add_argument(
+        "--skip-line-prefix",
+        action="append",
+        default=None,
+        metavar="PREFIX",
+        help="직접 제거할 prefix를 추가",
+    )
+    parser.add_argument(
+        "--no-chunk-normalize",
+        action="store_true",
+        help="정규화 생략(원문 그대로 저장)",
+    )
+    parser.add_argument(
+        "--no-footer-strip",
+        action="store_true",
+        help="푸터 제거만 끄기",
+    )
     return parser.parse_args()
 
 
-async def main():
+async def main() -> None:
     args = parse_args()
     if not args.input.is_file():
         raise FileNotFoundError(f"input 파일 없음: {args.input}")
@@ -80,11 +129,23 @@ async def main():
         raise ValueError("--batch-size는 1 이상이어야 함")
     if args.start_offset < 0:
         raise ValueError("--start-offset은 0 이상이어야 함")
+    if args.normalize_config is not None and args.skip_line_prefix is not None:
+        raise ValueError("--normalize-config와 --skip-line-prefix는 함께 쓸 수 없음")
 
     try:
         domain = VectorDomain(args.domain.lower())
     except ValueError as exc:
         raise ValueError(f"--domain은 {', '.join(d.value for d in VectorDomain)} 중 하나여야 함") from exc
+
+    skip_line_prefixes: tuple[str, ...] | None = None
+    if args.normalize_config is not None:
+        if not args.normalize_config.is_file():
+            raise FileNotFoundError(f"normalize 설정 파일 없음: {args.normalize_config}")
+        skip_line_prefixes = load_skip_line_prefixes(args.normalize_config)
+    elif args.skip_line_prefix is not None:
+        skip_line_prefixes = tuple(args.skip_line_prefix)
+
+    footer_line_prefixes: tuple[str, ...] | None = () if args.no_footer_strip else None
 
     svc = build_service()
     rows = load_jsonl(args.input)
@@ -103,7 +164,12 @@ async def main():
         processed += 1
 
         try:
-            node = row_to_node(row)
+            node = row_to_node(
+                row,
+                skip_line_prefixes=skip_line_prefixes,
+                footer_line_prefixes=footer_line_prefixes,
+                raw_text=args.no_chunk_normalize,
+            )
             node_id = node.node_id
             if not node_id or node_id in seen_ids:
                 skipped += 1
@@ -125,6 +191,7 @@ async def main():
         total += len(nodes)
 
     print(f"[done] table={table_name} inserted_total={total} skipped={skipped} processed={processed}")
+
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #32 

## ✨ 작업 개요
- QnA/TL1 청크 텍스트 정규화 공통 모듈(chunk_text_normalize.py) 추가
- QnA 메타 라벨 및 푸터 문구 제거
- QnA 형식 노이즈 제거
- TL1 메타 라벨 제거
- TL1/QnA 분류 정보는 metadata(category, subcategory, predication, department 등)로 유지되도록 확인
- 정규화 후 LlamaIndex + GoogleGenAIEmbedding 기반 임베딩 및 pgvector 적재 테스트 완료
- TL1/QnA 모두 동일 complaint 테이블에 적재 후 metadata(data_type) 기준으로 구분되는 것 확인

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
<img width="2508" height="476" alt="image" src="https://github.com/user-attachments/assets/fc696cfb-37c6-4400-b3eb-7fa0959d1cf8" />

## 🧐 집중 리뷰 요청
- 정규화 규칙이 과하게 적용되어 실제 검색에 필요한 본문까지 제거될 가능성이 없는지 봐주시면 좋겠습니다.