### PR TITLE
[REFACTOR] 임베딩 병렬 처리 

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -58,6 +58,11 @@ class Settings(BaseSettings):
         default="gemini-embedding-2",
         alias="GEMINI_EMBEDDING_MODEL",
     )
+    # None이면 모델별 기본값(embedding-2 → 1, 그 외 → 10). 지정 시 LlamaIndex embed_batch_size로 전달.
+    gemini_embedding_batch_size: int | None = Field(
+        default=None,
+        alias="GEMINI_EMBEDDING_BATCH_SIZE",
+    )
     vector_table_name: str = Field(default="complaint_chunks", alias="VECTOR_TABLE_NAME")
     vector_embed_dim: int = Field(default=1536, alias="VECTOR_EMBED_DIM")
     vector_dim_check: bool = Field(
@@ -69,6 +74,13 @@ class Settings(BaseSettings):
         default="simple",
         alias="VECTOR_TEXT_SEARCH_CONFIG",
     )
+
+    @field_validator("gemini_embedding_batch_size", mode="before")
+    @classmethod
+    def _empty_string_gemini_embed_batch(cls, value: object) -> object:
+        if value == "":
+            return None
+        return value
 
     @field_validator("redis_local_port", "redis_aws_port", "redis_aws_db", mode="before")
     @classmethod

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -60,6 +60,10 @@ class Settings(BaseSettings):
     )
     vector_table_name: str = Field(default="complaint_chunks", alias="VECTOR_TABLE_NAME")
     vector_embed_dim: int = Field(default=1536, alias="VECTOR_EMBED_DIM")
+    vector_dim_check: bool = Field(
+        default=False,
+        alias="VECTOR_DIM_CHECK",
+    )
     vector_hybrid_search: bool = Field(default=True, alias="VECTOR_HYBRID_SEARCH")
     vector_text_search_config: str = Field(
         default="simple",

--- a/app/main.py
+++ b/app/main.py
@@ -76,6 +76,7 @@ async def lifespan(app: FastAPI):
                 domain_configs=domain_configs,
                 hybrid_search=settings.vector_hybrid_search,
                 text_search_config=settings.vector_text_search_config,
+                embedding_batch_size_override=settings.gemini_embedding_batch_size,
             )
             if settings.vector_dim_check:
                 dimension_checks = (

--- a/app/services/VectorStoreService.py
+++ b/app/services/VectorStoreService.py
@@ -34,6 +34,7 @@ class VectorStoreService:
         domain_configs: dict[VectorDomain, DomainVectorConfig] | None = None,
         hybrid_search: bool = True,
         text_search_config: str = "simple",
+        embedding_batch_size_override: int | None = None,
     ) -> None:
         url = make_url(database_url)
         if not url.database:
@@ -60,6 +61,7 @@ class VectorStoreService:
         self._bundles: dict[str, _VectorIndexBundle] = {}
         self._domain_configs = domain_configs or {}
         self._embed_models: dict[tuple[str, int], BaseEmbedding] = {}
+        self._embedding_batch_size_override = embedding_batch_size_override
 
     @staticmethod
     def _normalize_domain(domain: str) -> str:
@@ -97,9 +99,12 @@ class VectorStoreService:
         embed_model = self._embed_models.get(model_key)
         if embed_model is not None:
             return embed_model
-        # gemini-embedding-2는 다중 입력 요청 시 응답 임베딩 수 불일치가 발생할 수 있어
-        # LlamaIndex 내부 배치를 1로 고정해 KeyError(id_to_embed_map 누락)를 방지한다.
-        embed_batch_size = 1 if model_name.strip().endswith("embedding-2") else 10
+        # gemini-embedding-2는 다중 입력 시 응답 수 불일치(KeyError) 이슈가 있어 기본 배치 1.
+        # GEMINI_EMBEDDING_BATCH_SIZE로 올리면 처리량↑ (API/버전에 따라 실패할 수 있음).
+        if self._embedding_batch_size_override is not None:
+            embed_batch_size = max(1, int(self._embedding_batch_size_override))
+        else:
+            embed_batch_size = 1 if model_name.strip().endswith("embedding-2") else 10
         embed_model = GoogleGenAIEmbedding(
             model_name=model_name,
             api_key=self._api_key,

--- a/app/utils/chunk_node_metadata.py
+++ b/app/utils/chunk_node_metadata.py
@@ -1,7 +1,7 @@
 """
 청크 JSONL 행 -> 벡터 DB / MetadataFilters용 메타데이터.
 메타데이터 만드는 공통 함수 파일이다.
-여기만 고치면 두 경로가 같이 바뀐다. (JSONL 실험 스크립트(embed_chunks_gemini)와 LlamaIndex insert_nodes 경로)
+여기만 고치면 청크 적재 경로(LlamaIndex insert_nodes 등)의 메타데이터가 함께 바뀐다.
 """
 
 from __future__ import annotations
@@ -11,6 +11,8 @@ from typing import Any, Mapping
 
 from llama_index.core.schema import TextNode
 
+# TL1(preprocess_tl1): category/subcategory/predication/department — 텍스트의 [민원 …] 라벨줄은
+# chunk_text_normalize 에서 제거하고, 필터용 값은 여기 메타로만 둔다.
 _OPTIONAL_FILTER_METADATA_KEYS = (
     "domain",
     "region",

--- a/app/utils/chunk_text_normalize.py
+++ b/app/utils/chunk_text_normalize.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+# 줄 시작이 이 접두어이면 제외 (None이면 이 기본값 사용)
+# TL1: [민원 …] 줄은 임베딩 텍스트에서만 제거. 분류·부서 값은 JSONL 행의
+# category, subcategory, predication, department → build_chunk_metadata 로 유지.
+DEFAULT_NORMALIZE_SKIP_PREFIXES: tuple[str, ...] = (
+    "[출처 기관]",
+    "[상담 분류]",
+    "[상담 일자]",
+    "[상담 내용]",
+    "[민원 대분류]",
+    "[민원 소분류]",
+    "[민원 유형]",
+    "[담당 부서]",
+    "[민원 내용]",
+)
+
+# 이 줄에서 잘리면 해당 줄과 이후 전부 제거
+DEFAULT_FOOTER_LINE_PREFIXES: tuple[str, ...] = (
+    "끝.",
+    "[본 회신내용",
+)
+
+# 행 전체를 버리는 QnA 답변 서식용 섹션 제목 (□ 질의 요지 등)
+DEFAULT_QNA_SECTION_HEADER_LINES: frozenset[str] = frozenset(
+    {
+        "□ 질의 요지",
+        "□질의 요지",
+        "□ 답변 내용",
+        "□답변 내용",
+    }
+)
+
+# 행 전체가 일치할 때만 제거 (고정 인사말 — 패턴이 확실한 문장만 추가)
+DEFAULT_QNA_GREETING_EXACT_LINES: frozenset[str] = frozenset(
+    {
+        "안녕하십니까? 평소 국토 교통행정에 관심과 애정을 가져 주신 점 깊이 감사드리며, 선생님께서 질의하신 사항에 대하여 아래와 같이 답변드립니다.",
+    }
+)
+
+_QA_LINE_PREFIX_RE = re.compile(r"^[QqAa]\s*:\s*")
+
+
+def _strip_leading_bullet_marks(line: str) -> str:
+    """줄 선두의 □ 또는 ㅇ 표기만 제거(연속 시 반복). 본문은 유지."""
+    s = line
+    while s:
+        if s.startswith("□"):
+            s = s[1:].lstrip()
+            continue
+        if s.startswith("ㅇ"):
+            s = s[1:].lstrip()
+            continue
+        break
+    return s
+
+
+def load_skip_line_prefixes(path: Path) -> tuple[str, ...]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"normalize 설정은 JSON 객체여야 함: {path}")
+    raw = data.get("skip_line_prefixes")
+    if raw is None:
+        raw = data.get("skip_prefixes")
+    if raw is None:
+        raise ValueError(
+            f"normalize 설정에 skip_line_prefixes 또는 skip_prefixes 배열이 필요함: {path}"
+        )
+    if not isinstance(raw, list):
+        raise ValueError(f"skip_line_prefixes는 문자열 배열이어야 함: {path}")
+    return tuple(str(x) for x in raw)
+
+
+def normalize_chunk(
+    chunk_text: str,
+    skip_line_prefixes: Optional[tuple[str, ...]] = None,
+    footer_line_prefixes: Optional[tuple[str, ...]] = None,
+    *,
+    qna_section_headers: Optional[frozenset[str]] = None,
+    qna_greeting_exact_lines: Optional[frozenset[str]] = None,
+) -> str:
+    """QnA/TL1 청크 공통: 메타 줄 제거 + 푸터(끝./회신 유의) 이후 절단
+
+    QnA 본문: Q:/A: 라벨·□/ㅇ 불릿 접두 제거, 질의/답변 섹션 제목 줄 삭제,
+    고정 인사말(전체 행 일치)만 삭제.
+
+    footer_line_prefixes가 ()이면 푸터 절단만 끈다. None이면 기본 푸터 규칙 사용
+    """
+    raw = chunk_text.strip()
+    if not raw:
+        return ""
+
+    prefixes = (
+        DEFAULT_NORMALIZE_SKIP_PREFIXES
+        if skip_line_prefixes is None
+        else skip_line_prefixes
+    )
+    if footer_line_prefixes is None:
+        footers = DEFAULT_FOOTER_LINE_PREFIXES
+    else:
+        footers = footer_line_prefixes
+
+    section_drop = (
+        DEFAULT_QNA_SECTION_HEADER_LINES
+        if qna_section_headers is None
+        else qna_section_headers
+    )
+    greeting_drop = (
+        DEFAULT_QNA_GREETING_EXACT_LINES
+        if qna_greeting_exact_lines is None
+        else qna_greeting_exact_lines
+    )
+
+    cleaned_lines: list[str] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if footers:
+            if stripped == "끝":
+                break
+            if stripped.startswith("끝."):
+                break
+            if stripped.startswith(footers):
+                break
+        if prefixes and stripped.startswith(prefixes):
+            continue
+        if stripped.startswith("제목 :"):
+            continue
+        if stripped in section_drop:
+            continue
+
+        after_qa = _QA_LINE_PREFIX_RE.sub("", stripped, count=1)
+        if after_qa in greeting_drop:
+            continue
+
+        after_bullets = _strip_leading_bullet_marks(after_qa)
+        if not after_bullets:
+            continue
+
+        cleaned_lines.append(after_bullets)
+
+    return "\n".join(cleaned_lines).strip()

--- a/app/utils/chunk_text_normalize.py
+++ b/app/utils/chunk_text_normalize.py
@@ -17,6 +17,7 @@ DEFAULT_NORMALIZE_SKIP_PREFIXES: tuple[str, ...] = (
     "[민원 유형]",
     "[담당 부서]",
     "[민원 내용]",
+    "제목 :",
 )
 
 # 이 줄에서 잘리면 해당 줄과 이후 전부 제거
@@ -80,9 +81,8 @@ def normalize_chunk(
     QnA 본문: Q:/A: 라벨 불릿 접두 제거, 질의/답변 섹션 제목 줄 삭제,
     고정 인사말(전체 행 일치)만 삭제.
 
-    footer_line_prefixes: None이면 DEFAULT_FOOTER_LINE_PREFIXES에 더해, 행 전체가
-    끝인 경우만 추가로 절단(끝나 같은 본문과 구분). ()이면 푸터 절단 전부 끔
-    그 외 비어 있지 않은 튜플이면 그 접두어들에 대한 startswith만 절단 기준으로
+    footer_line_prefixes: None이면 DEFAULT_FOOTER_LINE_PREFIXES를 사용하고,
+    추가로 행 전체가 정확히 "끝"인 경우도 푸터로 간주해 절단한다. ()이면 푸터 절단을 전부 끔
     """
     raw = chunk_text.strip()
     if not raw:
@@ -121,8 +121,6 @@ def normalize_chunk(
             if stripped.startswith(footers):
                 break
         if prefixes and stripped.startswith(prefixes):
-            continue
-        if stripped.startswith("제목 :"):
             continue
 
         after_qa = _QA_LINE_PREFIX_RE.sub("", stripped, count=1)

--- a/app/utils/chunk_text_normalize.py
+++ b/app/utils/chunk_text_normalize.py
@@ -6,8 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 # 줄 시작이 이 접두어이면 제외 (None이면 이 기본값 사용)
-# TL1: [민원 …] 줄은 임베딩 텍스트에서만 제거. 분류·부서 값은 JSONL 행의
-# category, subcategory, predication, department → build_chunk_metadata 로 유지.
+# TL1: [민원 …] 줄은 임베딩 텍스트에서만 제거. 부서 값은 JSONL 행의 category, subcategory.. → build_chunk_metadata 로
 DEFAULT_NORMALIZE_SKIP_PREFIXES: tuple[str, ...] = (
     "[출처 기관]",
     "[상담 분류]",
@@ -26,7 +25,7 @@ DEFAULT_FOOTER_LINE_PREFIXES: tuple[str, ...] = (
     "[본 회신내용",
 )
 
-# 행 전체를 버리는 QnA 답변 서식용 섹션 제목 (□ 질의 요지 등)
+# 행 전체를 버리는 QnA 답변 서식용 섹션 제목 (질의 요지 등)
 DEFAULT_QNA_SECTION_HEADER_LINES: frozenset[str] = frozenset(
     {
         "□ 질의 요지",
@@ -44,20 +43,12 @@ DEFAULT_QNA_GREETING_EXACT_LINES: frozenset[str] = frozenset(
 )
 
 _QA_LINE_PREFIX_RE = re.compile(r"^[QqAa]\s*:\s*")
+_STRIP_LEADING_BULLETS_RE = re.compile(r"^[□ㅇ\s]+")
 
 
 def _strip_leading_bullet_marks(line: str) -> str:
-    """줄 선두의 □ 또는 ㅇ 표기만 제거(연속 시 반복). 본문은 유지."""
-    s = line
-    while s:
-        if s.startswith("□"):
-            s = s[1:].lstrip()
-            continue
-        if s.startswith("ㅇ"):
-            s = s[1:].lstrip()
-            continue
-        break
-    return s
+    #줄 선두의 문자 및 인접 공백만 제거. 본문은 유지
+    return _STRIP_LEADING_BULLETS_RE.sub("", line)
 
 
 def load_skip_line_prefixes(path: Path) -> tuple[str, ...]:
@@ -84,12 +75,14 @@ def normalize_chunk(
     qna_section_headers: Optional[frozenset[str]] = None,
     qna_greeting_exact_lines: Optional[frozenset[str]] = None,
 ) -> str:
-    """QnA/TL1 청크 공통: 메타 줄 제거 + 푸터(끝./회신 유의) 이후 절단
+    """QnA/TL1 청크 공통: 메타 줄 제거 + 푸터 이후 절단
 
-    QnA 본문: Q:/A: 라벨·□/ㅇ 불릿 접두 제거, 질의/답변 섹션 제목 줄 삭제,
+    QnA 본문: Q:/A: 라벨 불릿 접두 제거, 질의/답변 섹션 제목 줄 삭제,
     고정 인사말(전체 행 일치)만 삭제.
 
-    footer_line_prefixes가 ()이면 푸터 절단만 끈다. None이면 기본 푸터 규칙 사용
+    footer_line_prefixes: None이면 DEFAULT_FOOTER_LINE_PREFIXES에 더해, 행 전체가
+    끝인 경우만 추가로 절단(끝나 같은 본문과 구분). ()이면 푸터 절단 전부 끔
+    그 외 비어 있지 않은 튜플이면 그 접두어들에 대한 startswith만 절단 기준으로
     """
     raw = chunk_text.strip()
     if not raw:
@@ -100,7 +93,8 @@ def normalize_chunk(
         if skip_line_prefixes is None
         else skip_line_prefixes
     )
-    if footer_line_prefixes is None:
+    default_footer = footer_line_prefixes is None
+    if default_footer:
         footers = DEFAULT_FOOTER_LINE_PREFIXES
     else:
         footers = footer_line_prefixes
@@ -122,9 +116,7 @@ def normalize_chunk(
         if not stripped:
             continue
         if footers:
-            if stripped == "끝":
-                break
-            if stripped.startswith("끝."):
+            if default_footer and stripped == "끝":
                 break
             if stripped.startswith(footers):
                 break
@@ -132,15 +124,13 @@ def normalize_chunk(
             continue
         if stripped.startswith("제목 :"):
             continue
-        if stripped in section_drop:
-            continue
 
         after_qa = _QA_LINE_PREFIX_RE.sub("", stripped, count=1)
-        if after_qa in greeting_drop:
+        if stripped in section_drop or after_qa in section_drop:
             continue
 
         after_bullets = _strip_leading_bullet_marks(after_qa)
-        if not after_bullets:
+        if not after_bullets or after_bullets in greeting_drop:
             continue
 
         cleaned_lines.append(after_bullets)

--- a/rag/scripts/chunk_module.py
+++ b/rag/scripts/chunk_module.py
@@ -1,18 +1,22 @@
 import hashlib
 import json
 import re
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 
-def load_jsonl(path: Path):
-    rows = []
+def iter_jsonl(path: Path) -> Iterator[Any]:
     with path.open("r", encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if not line:
                 continue
-            rows.append(json.loads(line))
-    return rows
+            yield json.loads(line)
+
+
+def load_jsonl(path: Path) -> list[Any]:
+    return list(iter_jsonl(path))
 
 
 def write_jsonl(path: Path, rows):

--- a/rag/scripts/embed_chunks_gemini.py
+++ b/rag/scripts/embed_chunks_gemini.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import json
 import os
 import sys
 from datetime import datetime, timezone
@@ -25,6 +24,7 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.append(str(_REPO_ROOT))
 
 from app.utils.chunk_node_metadata import build_chunk_metadata, chunk_data_type
+from app.utils.chunk_text_normalize import load_skip_line_prefixes, normalize_chunk
 
 from chunk_module import load_jsonl, write_jsonl
 from preprocess_module import OUTPUT_DIR
@@ -36,37 +36,12 @@ DEFAULT_MODEL = "gemini-embedding-2"
 DEFAULT_OUTPUT_DIMENSIONALITY = 1536
 # embed_content에 문자열 리스트를 넘기면 한 번의 요청으로 배치 임베딩 (RTT 감소)
 DEFAULT_EMBED_BATCH_SIZE = 100
-
 DEFAULT_EMBED_RETRY_ATTEMPTS = 8
 DEFAULT_EMBED_RETRY_WAIT_MIN_S = 2
 DEFAULT_EMBED_RETRY_WAIT_MAX_S = 120
 
-# normalize_chunk: 줄 시작이 이 접두어 중 하나면 제외 (None이면 이 기본값 사용)
-DEFAULT_NORMALIZE_SKIP_PREFIXES: tuple[str, ...] = (
-    "[출처 기관]",
-    "[상담 분류]",
-    "[상담 일자]",
-    "[상담 내용]",
-)
 
-
-def load_skip_line_prefixes(path: Path) -> tuple[str, ...]:
-    data = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(data, dict):
-        raise ValueError(f"normalize 설정은 JSON 객체여야 함: {path}")
-    raw = data.get("skip_line_prefixes")
-    if raw is None:
-        raw = data.get("skip_prefixes")
-    if raw is None:
-        raise ValueError(
-            f"normalize 설정에 skip_line_prefixes 또는 skip_prefixes 배열이 필요함: {path}"
-        )
-    if not isinstance(raw, list):
-        raise ValueError(f"skip_line_prefixes는 문자열 배열이어야 함: {path}")
-    return tuple(str(x) for x in raw)
-
-
-def is_retryable_error(exc: BaseException) -> bool:
+def _embedding_error_is_transient(exc: BaseException) -> bool:
     from google.genai import errors as genai_errors
 
     if isinstance(exc, genai_errors.ServerError):
@@ -94,7 +69,7 @@ EMBED_API_RETRY = Retrying(
         min=DEFAULT_EMBED_RETRY_WAIT_MIN_S,
         max=DEFAULT_EMBED_RETRY_WAIT_MAX_S,
     ),
-    retry=retry_if_exception(is_retryable_error),
+    retry=retry_if_exception(_embedding_error_is_transient),
     reraise=True,
 )
 
@@ -106,9 +81,8 @@ def now_utc() -> str:
 def sha1(text: str) -> str:
     return hashlib.sha1(text.encode("utf-8")).hexdigest()
 
-
 def gemini_model_id(model: str) -> str:
-    #API,embedding_id용 모델 id (models/ 접두어 제거).
+    #embedding_id용 모델 id (models/ 접두어 제거)
     m = model.strip()
     return m[len("models/") :] if m.startswith("models/") else m
 
@@ -129,45 +103,26 @@ def split_title_body(text: str) -> tuple[str, str]:
     return "제목 없음", raw
 
 
-def normalize_chunk(
-    chunk_text: str,
-    skip_line_prefixes: Optional[tuple[str, ...]] = None,
-) -> str:
-    raw = chunk_text.strip()
-    if not raw:
-        return ""
-
-    lines = raw.splitlines()
-    cleaned_lines = []
-    prefixes = (
-        DEFAULT_NORMALIZE_SKIP_PREFIXES
-        if skip_line_prefixes is None
-        else skip_line_prefixes
-    )
-
-    for line in lines:
-        stripped = line.strip()
-        if not stripped:
-            continue
-        if prefixes and stripped.startswith(prefixes):
-            continue
-        if stripped.startswith("제목 :"):
-            continue
-        cleaned_lines.append(stripped)
-
-    return "\n".join(cleaned_lines).strip()
-
-
 def build_qna_embedding_text(
     row: Dict,
     skip_line_prefixes: Optional[tuple[str, ...]] = None,
+    footer_line_prefixes: Optional[tuple[str, ...]] = None,
+    *,
+    normalized_chunk_body: Optional[str] = None,
 ) -> str:
     # TL1과 달리 QnA row의 text/rag_text에는 보통 제목 줄이 있어 split_title_body가 유효함.
     chunk_source = str(row.get("chunk_text") or "").strip()
     full_title, _ = split_title_body(
         str(row.get("rag_text") or row.get("text") or "").strip()
     )
-    body = normalize_chunk(chunk_source, skip_line_prefixes=skip_line_prefixes)
+    if normalized_chunk_body is not None:
+        body = normalized_chunk_body
+    else:
+        body = normalize_chunk(
+            chunk_source,
+            skip_line_prefixes=skip_line_prefixes,
+            footer_line_prefixes=footer_line_prefixes,
+        )
     if full_title and full_title != "제목 없음":
         return f"[제목] {full_title}\n[본문] {body}"
     return body
@@ -176,22 +131,40 @@ def build_qna_embedding_text(
 def build_tl1_embedding_text(
     row: Dict,
     skip_line_prefixes: Optional[tuple[str, ...]] = None,
+    footer_line_prefixes: Optional[tuple[str, ...]] = None,
 ) -> str:
-    # TL1: text/rag_text에 "제목 :" 형식이 없어 QnA처럼 제목 슬롯을 두면 [제목] 제목 없음만 붙음, 본문만 임베딩.
     chunk_source = str(
         row.get("chunk_text") or row.get("rag_text") or row.get("text") or ""
     ).strip()
-    return normalize_chunk(chunk_source, skip_line_prefixes=skip_line_prefixes)
+    return normalize_chunk(
+        chunk_source,
+        skip_line_prefixes=skip_line_prefixes,
+        footer_line_prefixes=footer_line_prefixes,
+    )
 
 
 def build_embedding_text(
     row: Dict,
     skip_line_prefixes: Optional[tuple[str, ...]] = None,
+    footer_line_prefixes: Optional[tuple[str, ...]] = None,
+    *,
+    normalized_chunk_body: Optional[str] = None,
 ) -> str:
     row_type = chunk_data_type(row)
     if row_type == "qna":
-        return build_qna_embedding_text(row, skip_line_prefixes=skip_line_prefixes)
-    return build_tl1_embedding_text(row, skip_line_prefixes=skip_line_prefixes)
+        return build_qna_embedding_text(
+            row,
+            skip_line_prefixes=skip_line_prefixes,
+            footer_line_prefixes=footer_line_prefixes,
+            normalized_chunk_body=normalized_chunk_body,
+        )
+    if normalized_chunk_body is not None:
+        return normalized_chunk_body
+    return build_tl1_embedding_text(
+        row,
+        skip_line_prefixes=skip_line_prefixes,
+        footer_line_prefixes=footer_line_prefixes,
+    )
 
 
 def _mock_embedding_vector(text: str, output_dimensionality: Optional[int]) -> List[float]:
@@ -275,6 +248,7 @@ def build_embedding_rows(
     client: Optional[genai.Client] = None,
     batch_size: int = DEFAULT_EMBED_BATCH_SIZE,
     skip_line_prefixes: Optional[tuple[str, ...]] = None,
+    footer_line_prefixes: Optional[tuple[str, ...]] = None,
 ) -> List[Dict]:
     work: List[Dict] = []
 
@@ -289,11 +263,20 @@ def build_embedding_rows(
             ).strip()
         else:
             raw_for_normalize = str(row.get("chunk_text") or "").strip()
-        body = normalize_chunk(raw_for_normalize, skip_line_prefixes=skip_line_prefixes)
+        body = normalize_chunk(
+            raw_for_normalize,
+            skip_line_prefixes=skip_line_prefixes,
+            footer_line_prefixes=footer_line_prefixes,
+        )
         if not body:
             continue
 
-        document_text = build_embedding_text(row, skip_line_prefixes=skip_line_prefixes)
+        document_text = build_embedding_text(
+            row,
+            skip_line_prefixes=skip_line_prefixes,
+            footer_line_prefixes=footer_line_prefixes,
+            normalized_chunk_body=body,
+        )
         chunk_id = str(row.get("chunk_id") or f"row::{idx}")
         work.append(
             {
@@ -308,8 +291,9 @@ def build_embedding_rows(
     if gemini_model_id(model) == "gemini-embedding-2" and not mock:
         if batch_size != 1:
             print(
-                "gemini-embedding-2는 embed_content 다중 텍스트 시 "
-                f"응답 임베딩이 1건만 와 batch_size를 {batch_size} → 1로 조정합니다.",
+                "gemini-embedding-2는 embed_content에서 다중 텍스트 입력 시 "
+                "임베딩을 1건만 반환하므로 batch_size를 "
+                f"{batch_size} → 1로 조정합니다.",
                 flush=True,
             )
         batch_size = 1
@@ -384,7 +368,7 @@ def main():
         type=int,
         default=None,
         metavar="N",
-        help="임베딩할 최대 청크 수 (미지정 시 전체). 테스트 시에만 지정 권장",
+        help="임베딩할 최대 청크 수. 샘플/테스트 시에만 지정 권장",
     )
     parser.add_argument(
         "--mock",
@@ -414,7 +398,12 @@ def main():
         action="append",
         default=None,
         metavar="PREFIX",
-        help="normalize_chunk에서 제거할 줄 접두어. 지정 시 기본 접두어 대신 이 목록만 사용",
+        help="normalize_chunk에서 제거할 줄 접두어 (여러 번 지정 가능). 지정 시 기본 접두어 대신 이 목록만 사용",
+    )
+    parser.add_argument(
+        "--no-footer-strip",
+        action="store_true",
+        help="끝./[본 회신… 푸터 절단 비활성화",
     )
     args = parser.parse_args()
     if args.log_every < 0:
@@ -432,6 +421,8 @@ def main():
         skip_line_prefixes = load_skip_line_prefixes(args.normalize_config)
     elif args.skip_line_prefix is not None:
         skip_line_prefixes = tuple(args.skip_line_prefix)
+
+    footer_line_prefixes: Optional[tuple[str, ...]] = () if args.no_footer_strip else None
 
     client = None
     if not args.mock:
@@ -460,6 +451,7 @@ def main():
         client=client,
         batch_size=args.batch_size,
         skip_line_prefixes=skip_line_prefixes,
+        footer_line_prefixes=footer_line_prefixes,
     )
     write_jsonl(output_path, out_rows)
     print(f"[done] embedded={len(out_rows)} output={output_path}")

--- a/rag/scripts/insert_chunks_to_vector.py
+++ b/rag/scripts/insert_chunks_to_vector.py
@@ -171,15 +171,27 @@ async def main() -> None:
                 raw_text=args.no_chunk_normalize,
             )
             node_id = node.node_id
-            if not node_id or node_id in seen_ids:
+            if not node_id:
+                print(f"[skip] missing node_id idx={idx} chunk_id={row.get('chunk_id')}")
                 skipped += 1
                 continue
+
+            if node_id in seen_ids:
+                print(f"[skip] duplicated node_id idx={idx} node_id={node_id}")
+                skipped += 1
+                continue
+
             seen_ids.add(node_id)
             nodes.append(node)
-        except Exception:
+
+        except Exception as e:
+            print(
+                f"[skip] exception idx={idx} "
+                f"chunk_id={row.get('chunk_id')} "
+                f"error={type(e).__name__}: {e}"
+            )
             skipped += 1
             continue
-
         if len(nodes) >= args.batch_size:
             table_name = await insert_batch_with_retry(svc, nodes, domain)
             total += len(nodes)

--- a/rag/scripts/insert_chunks_to_vector.py
+++ b/rag/scripts/insert_chunks_to_vector.py
@@ -12,11 +12,18 @@ from app.core.config import settings
 from app.services.VectorStoreService import VectorStoreService
 from app.services.vector_domains import DomainVectorConfig, VectorDomain
 from app.utils.chunk_node_metadata import build_chunk_metadata
+from app.utils.chunk_text_normalize import load_skip_line_prefixes, normalize_chunk
 from rag.scripts.chunk_module import load_jsonl
 
 DEFAULT_BATCH_SIZE = 50
 
+
 def build_service() -> VectorStoreService:
+    api_key_secret = settings.gemini_api_key
+    if api_key_secret is None:
+        raise RuntimeError(
+            "GEMINI_API_KEY가 없습니다. .env 또는 환경 변수 GEMINI_API_KEY를 설정한 뒤 다시 실행하세요."
+        )
     domain_configs = {
         VectorDomain.COMPLAINT: DomainVectorConfig(
             table_name="complaint",
@@ -28,7 +35,7 @@ def build_service() -> VectorStoreService:
     return VectorStoreService(
         database_url=settings.sync_database_url,
         async_database_url=settings.async_database_url,
-        api_key=settings.gemini_api_key.get_secret_value(),
+        api_key=api_key_secret.get_secret_value(),
         table_name=settings.vector_table_name,
         default_embedding_model=settings.gemini_embedding_model,
         default_embed_dim=settings.vector_embed_dim,
@@ -37,16 +44,34 @@ def build_service() -> VectorStoreService:
         text_search_config=settings.vector_text_search_config,
     )
 
-def row_to_node(row: dict) -> TextNode:
-    text = (row.get("chunk_text") or row.get("text") or "").strip()
-    if not text:
+
+def row_to_node(
+    row: dict,
+    *,
+    skip_line_prefixes: tuple[str, ...] | None = None,
+    footer_line_prefixes: tuple[str, ...] | None = None,
+    raw_text: bool = False,
+) -> TextNode:
+    raw = (row.get("chunk_text") or row.get("text") or "").strip()
+    if not raw:
         raise ValueError("empty text")
+    if raw_text:
+        text = raw
+    else:
+        text = normalize_chunk(
+            raw,
+            skip_line_prefixes=skip_line_prefixes,
+            footer_line_prefixes=footer_line_prefixes,
+        )
+    if not text:
+        raise ValueError("empty text after normalize")
     chunk_id = str(row.get("chunk_id") or "")
     return TextNode(
         text=text,
         id_=chunk_id,
         metadata=build_chunk_metadata(row),
     )
+
 
 @retry(
     retry=retry_if_exception_type((httpx.ConnectError, httpx.ReadTimeout, httpx.WriteError, TimeoutError)),
@@ -69,10 +94,34 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--limit", type=int, default=None)
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
     parser.add_argument("--start-offset", type=int, default=0)
+    parser.add_argument(
+        "--normalize-config",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="JSON: skip_line_prefixes(또는 skip_prefixes) 배열",
+    )
+    parser.add_argument(
+        "--skip-line-prefix",
+        action="append",
+        default=None,
+        metavar="PREFIX",
+        help="직접 제거할 prefix를 추가",
+    )
+    parser.add_argument(
+        "--no-chunk-normalize",
+        action="store_true",
+        help="정규화 생략(원문 그대로 저장)",
+    )
+    parser.add_argument(
+        "--no-footer-strip",
+        action="store_true",
+        help="푸터 제거만 끄기",
+    )
     return parser.parse_args()
 
 
-async def main():
+async def main() -> None:
     args = parse_args()
     if not args.input.is_file():
         raise FileNotFoundError(f"input 파일 없음: {args.input}")
@@ -80,11 +129,23 @@ async def main():
         raise ValueError("--batch-size는 1 이상이어야 함")
     if args.start_offset < 0:
         raise ValueError("--start-offset은 0 이상이어야 함")
+    if args.normalize_config is not None and args.skip_line_prefix is not None:
+        raise ValueError("--normalize-config와 --skip-line-prefix는 함께 쓸 수 없음")
 
     try:
         domain = VectorDomain(args.domain.lower())
     except ValueError as exc:
         raise ValueError(f"--domain은 {', '.join(d.value for d in VectorDomain)} 중 하나여야 함") from exc
+
+    skip_line_prefixes: tuple[str, ...] | None = None
+    if args.normalize_config is not None:
+        if not args.normalize_config.is_file():
+            raise FileNotFoundError(f"normalize 설정 파일 없음: {args.normalize_config}")
+        skip_line_prefixes = load_skip_line_prefixes(args.normalize_config)
+    elif args.skip_line_prefix is not None:
+        skip_line_prefixes = tuple(args.skip_line_prefix)
+
+    footer_line_prefixes: tuple[str, ...] | None = () if args.no_footer_strip else None
 
     svc = build_service()
     rows = load_jsonl(args.input)
@@ -103,7 +164,12 @@ async def main():
         processed += 1
 
         try:
-            node = row_to_node(row)
+            node = row_to_node(
+                row,
+                skip_line_prefixes=skip_line_prefixes,
+                footer_line_prefixes=footer_line_prefixes,
+                raw_text=args.no_chunk_normalize,
+            )
             node_id = node.node_id
             if not node_id or node_id in seen_ids:
                 skipped += 1
@@ -125,6 +191,7 @@ async def main():
         total += len(nodes)
 
     print(f"[done] table={table_name} inserted_total={total} skipped={skipped} processed={processed}")
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/rag/scripts/insert_chunks_to_vector.py
+++ b/rag/scripts/insert_chunks_to_vector.py
@@ -13,7 +13,7 @@ from app.services.VectorStoreService import VectorStoreService
 from app.services.vector_domains import DomainVectorConfig, VectorDomain
 from app.utils.chunk_node_metadata import build_chunk_metadata
 from app.utils.chunk_text_normalize import load_skip_line_prefixes, normalize_chunk
-from rag.scripts.chunk_module import load_jsonl
+from rag.scripts.chunk_module import iter_jsonl
 
 DEFAULT_BATCH_SIZE = 50
 
@@ -118,6 +118,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="푸터 제거만 끄기",
     )
+    parser.add_argument(
+        "--no-dedupe-node",
+        action="store_true",
+        help="입력이 이미 유일하거나 DB/상위 파이프라인에서 중복을 처리할 때 사용",
+    )
     return parser.parse_args()
 
 
@@ -148,15 +153,14 @@ async def main() -> None:
     footer_line_prefixes: tuple[str, ...] | None = () if args.no_footer_strip else None
 
     svc = build_service()
-    rows = load_jsonl(args.input)
     nodes: list[TextNode] = []
     total = 0
     skipped = 0
     processed = 0
     table_name = ""
-    seen_ids: set[str] = set()
+    seen_ids: set[str] | None = None if args.no_dedupe_node else set()
 
-    for idx, row in enumerate(rows):
+    for idx, row in enumerate(iter_jsonl(args.input)):
         if idx < args.start_offset:
             continue
         if args.limit is not None and processed >= args.limit:
@@ -176,12 +180,12 @@ async def main() -> None:
                 skipped += 1
                 continue
 
-            if node_id in seen_ids:
-                print(f"[skip] duplicated node_id idx={idx} node_id={node_id}")
-                skipped += 1
-                continue
-
-            seen_ids.add(node_id)
+            if seen_ids is not None:
+                if node_id in seen_ids:
+                    print(f"[skip] duplicated node_id idx={idx} node_id={node_id}")
+                    skipped += 1
+                    continue
+                seen_ids.add(node_id)
             nodes.append(node)
 
         except Exception as e:

--- a/rag/scripts/insert_chunks_to_vector.py
+++ b/rag/scripts/insert_chunks_to_vector.py
@@ -16,6 +16,8 @@ from app.utils.chunk_text_normalize import load_skip_line_prefixes, normalize_ch
 from rag.scripts.chunk_module import iter_jsonl
 
 DEFAULT_BATCH_SIZE = 50
+# 동시에 진행 중인 insert 배치 수 상한 (메모리·API 한도 완화)
+DEFAULT_MAX_PENDING_BATCHES_FACTOR = 4
 
 
 def build_service() -> VectorStoreService:
@@ -42,6 +44,7 @@ def build_service() -> VectorStoreService:
         domain_configs=domain_configs,
         hybrid_search=settings.vector_hybrid_search,
         text_search_config=settings.vector_text_search_config,
+        embedding_batch_size_override=settings.gemini_embedding_batch_size,
     )
 
 
@@ -95,6 +98,19 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
     parser.add_argument("--start-offset", type=int, default=0)
     parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=1,
+        help="동시 insert 배치 수(각각 별도 VectorStoreService). 2~6 권장. API 한도/DB 부하에 맞춰 조절.",
+    )
+    parser.add_argument(
+        "--max-pending-batches",
+        type=int,
+        default=None,
+        metavar="N",
+        help="큐에 쌓아 둘 배치 상한(기본: concurrency * 4). 메모리·백프레셔 조절.",
+    )
+    parser.add_argument(
         "--normalize-config",
         type=Path,
         default=None,
@@ -134,6 +150,8 @@ async def main() -> None:
         raise ValueError("--batch-size는 1 이상이어야 함")
     if args.start_offset < 0:
         raise ValueError("--start-offset은 0 이상이어야 함")
+    if args.concurrency < 1:
+        raise ValueError("--concurrency는 1 이상이어야 함")
     if args.normalize_config is not None and args.skip_line_prefix is not None:
         raise ValueError("--normalize-config와 --skip-line-prefix는 함께 쓸 수 없음")
 
@@ -152,13 +170,100 @@ async def main() -> None:
 
     footer_line_prefixes: tuple[str, ...] | None = () if args.no_footer_strip else None
 
-    svc = build_service()
-    nodes: list[TextNode] = []
     total = 0
     skipped = 0
     processed = 0
     table_name = ""
     seen_ids: set[str] | None = None if args.no_dedupe_node else set()
+
+    max_pending = args.max_pending_batches
+    if max_pending is None:
+        max_pending = max(
+            args.concurrency * DEFAULT_MAX_PENDING_BATCHES_FACTOR,
+            args.concurrency + 1,
+        )
+
+    if args.concurrency <= 1:
+        svc = build_service()
+        nodes: list[TextNode] = []
+
+        for idx, row in enumerate(iter_jsonl(args.input)):
+            if idx < args.start_offset:
+                continue
+            if args.limit is not None and processed >= args.limit:
+                break
+            processed += 1
+
+            try:
+                node = row_to_node(
+                    row,
+                    skip_line_prefixes=skip_line_prefixes,
+                    footer_line_prefixes=footer_line_prefixes,
+                    raw_text=args.no_chunk_normalize,
+                )
+                node_id = node.node_id
+                if not node_id:
+                    print(f"[skip] missing node_id idx={idx} chunk_id={row.get('chunk_id')}")
+                    skipped += 1
+                    continue
+
+                if seen_ids is not None:
+                    if node_id in seen_ids:
+                        print(f"[skip] duplicated node_id idx={idx} node_id={node_id}")
+                        skipped += 1
+                        continue
+                    seen_ids.add(node_id)
+                nodes.append(node)
+
+            except Exception as e:
+                print(
+                    f"[skip] exception idx={idx} "
+                    f"chunk_id={row.get('chunk_id')} "
+                    f"error={type(e).__name__}: {e}"
+                )
+                skipped += 1
+                continue
+            if len(nodes) >= args.batch_size:
+                table_name = await insert_batch_with_retry(svc, nodes, domain)
+                total += len(nodes)
+                print(f"[progress] inserted={total} skipped={skipped} last_batch={len(nodes)}")
+                nodes = []
+
+        if nodes:
+            table_name = await insert_batch_with_retry(svc, nodes, domain)
+            total += len(nodes)
+
+        print(f"[done] table={table_name} inserted_total={total} skipped={skipped} processed={processed}")
+        return
+
+    # 병렬: 서비스 풀(클라이언트 분리) + 제한된 in-flight Task
+    svc_pool: asyncio.Queue[VectorStoreService] = asyncio.Queue()
+    for _ in range(args.concurrency):
+        await svc_pool.put(build_service())
+
+    async def insert_with_pool(batch: list[TextNode]) -> tuple[str, int]:
+        svc = await svc_pool.get()
+        try:
+            tname = await insert_batch_with_retry(svc, batch, domain)
+            return tname, len(batch)
+        finally:
+            await svc_pool.put(svc)
+
+    tasks: list[asyncio.Task[tuple[str, int]]] = []
+    nodes_buf: list[TextNode] = []
+
+    async def drain_some_tasks() -> None:
+        nonlocal tasks, table_name, total
+        if not tasks:
+            return
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        for d in done:
+            tname, n = d.result()
+            total += n
+            if tname:
+                table_name = tname
+            print(f"[progress] inserted={total} skipped={skipped} last_batch={n}")
+        tasks = list(pending)
 
     for idx, row in enumerate(iter_jsonl(args.input)):
         if idx < args.start_offset:
@@ -186,7 +291,7 @@ async def main() -> None:
                     skipped += 1
                     continue
                 seen_ids.add(node_id)
-            nodes.append(node)
+            nodes_buf.append(node)
 
         except Exception as e:
             print(
@@ -196,17 +301,34 @@ async def main() -> None:
             )
             skipped += 1
             continue
-        if len(nodes) >= args.batch_size:
-            table_name = await insert_batch_with_retry(svc, nodes, domain)
-            total += len(nodes)
-            print(f"[progress] inserted={total} skipped={skipped} last_batch={len(nodes)}")
-            nodes = []
 
-    if nodes:
-        table_name = await insert_batch_with_retry(svc, nodes, domain)
-        total += len(nodes)
+        if len(nodes_buf) >= args.batch_size:
+            batch = nodes_buf
+            nodes_buf = []
+            while len(tasks) >= max_pending:
+                await drain_some_tasks()
+            tasks.append(asyncio.create_task(insert_with_pool(batch)))
 
-    print(f"[done] table={table_name} inserted_total={total} skipped={skipped} processed={processed}")
+    if nodes_buf:
+        while len(tasks) >= max_pending:
+            await drain_some_tasks()
+        tasks.append(asyncio.create_task(insert_with_pool(nodes_buf)))
+
+    if tasks:
+        results = await asyncio.gather(*tasks)
+        for tname, n in results:
+            total += n
+            if tname:
+                table_name = tname
+            print(f"[progress] inserted={total} skipped={skipped} last_batch={n}")
+
+    if not table_name:
+        table_name = build_service().get_table_name(domain=domain.value)
+
+    print(
+        f"[done] table={table_name} inserted_total={total} skipped={skipped} "
+        f"processed={processed} concurrency={args.concurrency}"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #36 

## ✨ 작업 개요
대용량 RAG 청크 임베딩 적재 속도 개선을 위해 병렬 적재 옵션을 추가했습니다.
기존에는 `insert_chunks_to_vector.py`에서 배치를 하나씩 순차 처리해 Gemini 임베딩 API 호출 대기 시간이 그대로 누적되었습니다.  
이번 작업에서는 `--concurrency` 옵션을 추가하여 여러 배치를 동시에 처리할 수 있도록 개선했습니다.

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [ ] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
<img width="2704" height="678" alt="image" src="https://github.com/user-attachments/assets/d53d4fe3-8f70-4341-8c70-4fc09456a062" />

## 🧐 집중 리뷰 요청