### PR TITLE
Feat/ai pin content generater

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -69,7 +69,7 @@ class Settings(BaseSettings):
         alias="GEMINI_VLM_MODEL",
     )
     gemini_pin_text_model: str = Field(
-        default="gemini-2.0-flash",
+        default="gemini-2.5-flash",
         alias="GEMINI_PIN_TEXT_MODEL",
     )
     gemini_embedding_model: str = Field(

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,10 @@
 from contextlib import asynccontextmanager
 import logging
+from typing import Any
 
 import httpx
 from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
 from starlette.responses import JSONResponse
 
 from app import models  # noqa: F401
@@ -125,6 +127,38 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+
+
+def _patch_binary_media_schema(node: Any) -> None:
+    if isinstance(node, dict):
+        if node.get("type") == "string" and node.get("contentMediaType") == "application/octet-stream":
+            node.pop("contentMediaType", None)
+            node["format"] = "binary"
+        for value in node.values():
+            _patch_binary_media_schema(value)
+        return
+    if isinstance(node, list):
+        for item in node:
+            _patch_binary_media_schema(item)
+
+
+def custom_openapi() -> dict[str, Any]:
+    if app.openapi_schema:
+        return app.openapi_schema
+
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        description=app.description,
+        routes=app.routes,
+    )
+    _patch_binary_media_schema(openapi_schema)
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+
+app.openapi = custom_openapi
 
 register_exception_handlers(app)
 for router in enabled_routers:

--- a/app/models/Pin.py
+++ b/app/models/Pin.py
@@ -11,6 +11,7 @@ from app.models.enum.ToneType import ToneType
 
 if TYPE_CHECKING:
     from app.models.EventPin import EventPin
+    from app.models.IssuePin import IssuePin
     from app.models.PinImage import PinImage
     from app.models.PinLocation import PinLocation
     from app.models.User import User
@@ -66,6 +67,12 @@ class Pin(BaseEntity):
     )
     event_pin: Mapped[EventPin | None] = relationship(
         "EventPin",
+        back_populates="pin",
+        uselist=False,
+        lazy="selectin",
+    )
+    issue_pin: Mapped[IssuePin | None] = relationship(
+        "IssuePin",
         back_populates="pin",
         uselist=False,
         lazy="selectin",

--- a/app/routes/IssueRoute.py
+++ b/app/routes/IssueRoute.py
@@ -1,8 +1,12 @@
-from fastapi import APIRouter
+from typing import Annotated
+
+from fastapi import APIRouter, File, Form, UploadFile
 
 from app.core.codes import SuccessCode
+from app.core.deps import CurrentUserIdDep, IssueServiceDep
 from app.core.responses import success_response
 from app.models.enum.ToneType import ToneType
+from app.schemas.IssueDTO import CreateIssuePinRequest
 
 router = APIRouter(prefix="/issues", tags=["issue"])
 
@@ -11,3 +15,29 @@ router = APIRouter(prefix="/issues", tags=["issue"])
 async def get_tone_types():
     result = [{"key": t.name, "label": t.value} for t in ToneType]
     return success_response(result=result, success_code=SuccessCode.OK)
+
+
+@router.post("/pin/ai")
+async def create_issue_pin_ai(
+    uid: CurrentUserIdDep,
+    issue_service: IssueServiceDep,
+    images: Annotated[list[UploadFile], File(...)],
+    title: str = Form(...),
+    content: str = Form(...),
+    tone: ToneType = Form(ToneType.NONE),
+    latitude: float = Form(...),
+    longitude: float = Form(...),
+):
+    request = CreateIssuePinRequest(
+        title=title,
+        content=content,
+        tone=tone,
+        latitude=latitude,
+        longitude=longitude,
+    )
+    result = await issue_service.issue_pin_ai_make(
+        uid=uid,
+        images=images,
+        request=request,
+    )
+    return success_response(result=result, success_code=SuccessCode.CREATED)

--- a/app/schemas/IssueDTO.py
+++ b/app/schemas/IssueDTO.py
@@ -21,9 +21,20 @@ class ImageWithLocation(BaseModel):
     address: str | None = None
 
 
+class ReliabilityBasis(BaseModel):
+    confidence_score: float
+    validity: bool
+    location_verification_status: str | None = None
+    location_verification_message: str | None = None
+    error_code: str | None = None
+    risk_note: str | None = None
+    scene_summary: str | None = None
+
+
 class IssueAnalysisResult(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     title: str
     content: str
     reliability: float
+    reliability_basis: ReliabilityBasis

--- a/app/schemas/UserDTO.py
+++ b/app/schemas/UserDTO.py
@@ -11,13 +11,6 @@ class UserDTO(BaseModel):
 
     uid: str
     user_name: str
-    phone: str | None = None
-    nickname: str | None = None
-    email: str | None = None
-    location_id: int | None = None
-    event_alarm_active: bool
-    hot_alarm_active: bool
-    store_alarm_active: bool
-    like_alarm_active: bool
+
     created_at: datetime
     updated_at: datetime | None = None

--- a/app/services/IssueService.py
+++ b/app/services/IssueService.py
@@ -61,19 +61,14 @@ class IssueService:
         if not isinstance(raw, dict):
             return None
         domain_name = raw.get("domain")
-        type_name = raw.get("type")
-        parts: list[MetadataFilter] = []
-        if isinstance(domain_name, str):
-            d = domain_name.strip()
-            if d and d != "공통":
-                parts.append(MetadataFilter(key="domain", value=d))
-        if isinstance(type_name, str):
-            t = type_name.strip()
-            if t:
-                parts.append(MetadataFilter(key="category", value=t))
-        if not parts:
+        if not isinstance(domain_name, str):
             return None
-        return MetadataFilters(filters=parts)
+        d = domain_name.strip()
+        if not d or d == "공통":
+            return None
+        return MetadataFilters(
+            filters=[MetadataFilter(key="category", value=d)]
+        )
 
     @staticmethod
     def _rag_hits_to_dicts(hits: Any) -> list[dict[str, Any]]:
@@ -154,13 +149,17 @@ class IssueService:
             query = user_content.strip()
 
         filters = self._build_rag_metadata_filters(vlm_result)
+        logger.warning(
+            "RAG retrieve start — query=%r, domain=%s, filters=%s",
+            query, VectorDomain.COMPLAINT.value, filters,
+        )
         rag_hits = await self._vector_store_service.aretrieve(
             query=query,
             domain=VectorDomain.COMPLAINT,
             similarity_top_k=10,
             filters=filters,
         )
-        logger.info("Issue RAG hits exists: %s", bool(rag_hits))
+        logger.warning("Issue RAG hits count=%d, hits=%s", len(rag_hits), rag_hits)
         rag_payload = self._rag_hits_to_dicts(rag_hits)
 
         bundle: dict[str, Any] = {

--- a/app/services/IssueService.py
+++ b/app/services/IssueService.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from fastapi import UploadFile
@@ -10,7 +11,12 @@ from app.core.exceptions import raise_business_exception
 from app.repositories.IssuePinRepo import IssuePinRepo
 from app.repositories.PinRepo import PinRepo
 from app.repositories.UserRepo import UserRepo
-from app.schemas.IssueDTO import CreateIssuePinRequest, ImageWithLocation, IssueAnalysisResult
+from app.schemas.IssueDTO import (
+    CreateIssuePinRequest,
+    ImageWithLocation,
+    IssueAnalysisResult,
+    ReliabilityBasis,
+)
 from app.services.ImageExifLocationResolveService import ImageExifLocationResolveService
 from app.services.issue_pin_prompt import build_issue_pin_prompt_from_pipeline_bundle
 from app.services.IssuePinLLMService import IssuePinLLMService
@@ -19,6 +25,7 @@ from app.services.VLMService import VLMService
 from app.services.VectorStoreService import VectorStoreService
 
 MAX_IMAGES = 5
+logger = logging.getLogger(__name__)
 
 
 class IssueService:
@@ -84,6 +91,13 @@ class IssueService:
         return rows
 
     @staticmethod
+    def _optional_text(value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        text = value.strip()
+        return text or None
+
+    @staticmethod
     def _reliability_from_vlm(vlm_result: dict[str, Any]) -> float:
         raw = vlm_result.get("confidence_score")
         try:
@@ -92,14 +106,35 @@ class IssueService:
             return 0.0
         return max(0.0, min(1.0, score))
 
-    async def create_issue_pin(
+    @staticmethod
+    def _reliability_basis_from_vlm(vlm_result: dict[str, Any]) -> ReliabilityBasis:
+        location_status: str | None = None
+        location_message: str | None = None
+        location_verification = vlm_result.get("location_verification")
+        if isinstance(location_verification, dict):
+            location_status = IssueService._optional_text(location_verification.get("status"))
+            location_message = IssueService._optional_text(location_verification.get("message"))
+
+        raw_validity = vlm_result.get("validity")
+        validity = raw_validity if isinstance(raw_validity, bool) else False
+
+        return ReliabilityBasis(
+            confidence_score=IssueService._reliability_from_vlm(vlm_result),
+            validity=validity,
+            location_verification_status=location_status,
+            location_verification_message=location_message,
+            error_code=IssueService._optional_text(vlm_result.get("error_code")),
+            risk_note=IssueService._optional_text(vlm_result.get("risk_note")),
+            scene_summary=IssueService._optional_text(vlm_result.get("scene_summary")),
+        )
+
+    async def issue_pin_ai_make(
         self,
         *,
         uid: str,
         images: list[UploadFile],
         request: CreateIssuePinRequest,
     ) -> IssueAnalysisResult:
-        _ = uid
 
         if not images:
             raise_business_exception(ErrorCode.VALIDATION_ERROR, detail="이미지는 1장 이상 필요합니다.")
@@ -125,6 +160,7 @@ class IssueService:
             similarity_top_k=10,
             filters=filters,
         )
+        logger.info("Issue RAG hits exists: %s", bool(rag_hits))
         rag_payload = self._rag_hits_to_dicts(rag_hits)
 
         bundle: dict[str, Any] = {
@@ -148,6 +184,7 @@ class IssueService:
             title=request.title,
             content=pin_body,
             reliability=self._reliability_from_vlm(vlm_result),
+            reliability_basis=self._reliability_basis_from_vlm(vlm_result),
         )
 
     async def _extract_locations_from_images(

--- a/app/services/VectorStoreService.py
+++ b/app/services/VectorStoreService.py
@@ -41,8 +41,6 @@ class VectorStoreService:
             raise ValueError("Vector DB database name is required.")
         if not url.host:
             raise ValueError("Vector DB host is required.")
-        if not url.username:
-            raise ValueError("Vector DB user is required.")
         if url.port is None:
             raise ValueError("Vector DB port is required.")
 

--- a/app/services/VectorStoreService.py
+++ b/app/services/VectorStoreService.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 from typing import Any
@@ -14,6 +15,8 @@ from sqlalchemy import make_url
 from starlette.concurrency import run_in_threadpool
 
 from app.services.vector_domains import DomainVectorConfig, VectorDomain
+
+logger = logging.getLogger(__name__)
 
 @dataclass(slots=True)
 class _VectorIndexBundle:
@@ -226,6 +229,11 @@ class VectorStoreService:
             domain_config.embedding_model if domain_config else self._default_embedding_model
         )
         embed_dim = domain_config.embed_dim if domain_config else self._default_embed_dim
+        logger.warning(
+            "aretrieve — table=%s, model=%s, dim=%d, mode=%s, top_k=%d, filters=%s",
+            resolved_table_name, embed_model_name, embed_dim,
+            vector_store_query_mode, similarity_top_k, filters,
+        )
         bundle = self._get_or_create_bundle(
             resolved_table_name=resolved_table_name,
             embed_model_name=embed_model_name,
@@ -236,4 +244,6 @@ class VectorStoreService:
             filters=filters,
             vector_store_query_mode=vector_store_query_mode,
         )
-        return await retriever.aretrieve(query)
+        results = await retriever.aretrieve(query)
+        logger.warning("aretrieve — returned %d nodes", len(results))
+        return results


### PR DESCRIPTION

## ✨ 작업 개요
> VLM 결과로부터 구성하던 RAG 메타데이터 필터를 실제 인덱스 메타데이터(category)와 맞추고, 이슈 RAG 경로와 벡터 스토어 aretrieve에 상세 로그를 추가해 운영·디버깅 시 조회 조건과 결과를 확인하기 쉽게 합니다
변경 사항
IssueService
_build_rag_metadata_filters: type 기반 필터를 제거하고, 문자열 domain만 사용합니다. 값이 비어 있거나 "공통"이면 필터 없음으로 두고, 그 외에는 MetadataFilter(key="category", value=domain) 한 건만 적용합니다.
RAG 조회 직전에 쿼리·도메인·필터를 warning으로 남기고, 조회 후에는 hit 개수와 내용을 로그로 남깁니다.
VectorStoreService
aretrieve 진입 시 테이블명, 임베딩 모델, 차원, 쿼리 모드, top_k, 필터를 warning으로 기록합니다.
검색 완료 후 반환 노드 개수를 로그로 남깁니다.

## 체크리스트
- [X] Reviewers, Assignees, Labels를 모두 등록했나요?
- [X] .gitignore 설정을 하였나요?
- [X] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
<img width="1452" height="1748" alt="image" src="https://github.com/user-attachments/assets/7cac9c35-d5ff-4446-9057-9df7bad08664" />

## 🧐 집중 리뷰 요청

 이슈 생성/핀 AI 플로우에서 RAG가 기대한 category로만 필터되는지 확인

 로그 레벨·로그량이 운영 정책에 맞는지 확인 (현재 warning 다수)
참고
.vscode/settings.json은 로컬 설정이면 PR에 포함하지 않는 것을 권장합니다.