### PR TITLE
fix:issue 신뢰도 조회를 이슈핀 id에서 핀 id로 조회하도록 수정

### DIFF
--- a/app/repositories/IssuePinRepo.py
+++ b/app/repositories/IssuePinRepo.py
@@ -21,7 +21,9 @@ class IssuePinRepo(BaseRepo[IssuePin]):
 
     async def get_by_pin_id(self, pin_id: int) -> IssuePin | None:
         result = await self.session.execute(
-            select(IssuePin).where(IssuePin.pin_id == pin_id),
+            select(IssuePin)
+            .where(IssuePin.pin_id == pin_id)
+            .options(*_ISSUE_PIN_LOAD_OPTIONS),
         )
         return result.scalar_one_or_none()
 

--- a/app/routes/IssueRoute.py
+++ b/app/routes/IssueRoute.py
@@ -70,15 +70,15 @@ async def create_issue_pin(
     )
 
 
-@router.get("/pin/{issue_pin_id}/reliability")
+@router.get("/pin/{pin_id}/reliability")
 async def get_issue_pin_reliability(
-    issue_pin_id: int,
+    pin_id: int,
     uid: CurrentUserIdDep,
     issue_service: IssueServiceDep,
 ):
     result = await issue_service.get_issue_pin_reliability(
         uid=uid,
-        issue_pin_id=issue_pin_id,
+        pin_id=pin_id,
     )
     return success_response(
         result=result.model_dump(by_alias=True, exclude_none=False),

--- a/app/services/IssueService.py
+++ b/app/services/IssueService.py
@@ -543,13 +543,16 @@ class IssueService:
         self,
         *,
         uid: str,
-        issue_pin_id: int,
+        pin_id: int,
     ) -> IssuePinReliabilityResponse:
-        issue_pin = await self._issue_pin_repo.get_by_issue_pin_id(issue_pin_id)
+        _ = uid
+        issue_pin = await self._issue_pin_repo.get_by_pin_id(pin_id)
         if issue_pin is None or issue_pin.pin is None:
             raise_business_exception(ErrorCode.ISSUE_NOT_FOUND)
 
         pin = issue_pin.pin
+        if pin.pin_type != PinType.ISSUE:
+            raise_business_exception(ErrorCode.ISSUE_NOT_FOUND)
         pin_images = list(pin.pin_images or [])
         reliability = self._derive_reliability_status(
             issue_confidence=issue_pin.issue_confidence,

--- a/docs/issue-pin-create-and-reliability.md
+++ b/docs/issue-pin-create-and-reliability.md
@@ -52,7 +52,7 @@
 1. **미리보기**: `POST /issues/pin/ai` → AI가 제안한 `title` / `content`
 2. **편집**: 프론트에서 사용자가 문구 수정
 3. **게시**: `POST /issues/pin` → 최종 문구·좌표·(선택) 이미지 저장
-4. **폴링**: `GET /issues/pin/{id}/reliability` 또는 상세 API로 신뢰도 완료 확인
+4. **폴링**: `GET /issues/pin/{pin_id}/reliability` 또는 상세 API로 신뢰도 완료 확인
 
 ### 2.2 서버가 하지 않는 일
 
@@ -197,7 +197,7 @@ AI 미리보기. **DB 저장 없음.**
 
 ---
 
-### 4.5 `GET /issues/pin/{issue_pin_id}/reliability`
+### 4.5 `GET /issues/pin/{pin_id}/reliability`
 
 신뢰도 전용 폴링.
 
@@ -469,7 +469,7 @@ class IssuePinReliabilityJob:
 
 - `POST /issues/pin` 추가 (`BackgroundTasks` 주입)
 - `GET /issues/pin/{issue_pin_id}` 추가
-- `GET /issues/pin/{issue_pin_id}/reliability` 추가
+- `GET /issues/pin/{pin_id}/reliability` 추가
 
 ### 12.2 `app/services/IssueService.py`
 
@@ -503,7 +503,7 @@ class IssuePinReliabilityJob:
 
 ### 12.7 `app/repositories/IssuePinRepo.py`
 
-- `get_by_issue_pin_id` + `selectinload` (pin, images, location, user)
+- `get_by_issue_pin_id`, `get_by_pin_id` + `selectinload` (pin, images, location, user)
 - `update_confidence`: SQL `UPDATE` (get+flush 대신)
 
 ### 12.8 `app/models/IssuePin.py`
@@ -633,7 +633,7 @@ class IssuePinReliabilityJob:
 
 - [ ] `POST /issues/pin/ai` → 편집 → `POST /issues/pin` 2단계
 - [ ] 게시 응답 `reliabilityStatus === 'pending'` 이면 신뢰도 폴링
-- [ ] `GET .../reliability` 또는 상세에서 `issueConfidence`, `confidenceContent` 표시
+- [ ] `GET /issues/pin/{pin_id}/reliability` 또는 상세에서 `issueConfidence`, `confidenceContent` 표시
 - [ ] `confidenceContent` 줄바꿈 (`\n`) 렌더링
 - [ ] `reliabilityStatus === 'failed'` 시 재시도 안내 UI
 - [ ] 이미지 0장 게시 지원


### PR DESCRIPTION
- 이슈핀 신뢰도 조회 API 경로를 `GET /issues/pin/{issue_pin_id}/reliability`에서 `GET /issues/pin/{pin_id}/reliability`로 변경했습니다.
- 서비스 조회 기준을 `issue_pin_id`에서 `pin_id`로 전환하고, 조회된 핀이 실제 이슈 핀인지(`PinType.ISSUE`) 검증 로직을 추가했습니다.
- `IssuePinRepo.get_by_pin_id`에도 연관 로딩(`selectinload`)을 적용해 응답 생성 시 lazy-loading 이슈를 예방했습니다.
- 관련 문서(`docs/issue-pin-create-and-reliability.md`)의 신뢰도 폴링 경로 및 안내 문구를 `pin_id` 기준으로 업데이트했습니다.
