### PR TITLE
Feat/76 issue 수정 api 구현

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,20 @@ from app.utils.vector import ensure_pgvector_extension
 
 logger = logging.getLogger(__name__)
 
+
+def _configure_local_logging() -> None:
+    if settings.env != "local":
+        return
+    root_logger = logging.getLogger()
+    if root_logger.level > logging.INFO:
+        root_logger.setLevel(logging.INFO)
+    logging.getLogger("app").setLevel(logging.INFO)
+    logger.info("Local logging level configured to INFO")
+
+
+_configure_local_logging()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
 

--- a/app/repositories/IssuePinRepo.py
+++ b/app/repositories/IssuePinRepo.py
@@ -52,3 +52,15 @@ class IssuePinRepo(BaseRepo[IssuePin]):
         )
         await self.session.flush()
         return (result.rowcount or 0) > 0
+
+    async def reset_confidence(self, issue_pin_id: int) -> bool:
+        result = await self.session.execute(
+            update(IssuePin)
+            .where(IssuePin.issue_pin_id == issue_pin_id)
+            .values(
+                issue_confidence=None,
+                confidence_content=None,
+            ),
+        )
+        await self.session.flush()
+        return (result.rowcount or 0) > 0

--- a/app/repositories/PinImageRepo.py
+++ b/app/repositories/PinImageRepo.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.PinImage import PinImage
@@ -18,3 +18,10 @@ class PinImageRepo(BaseRepo[PinImage]):
             .order_by(PinImage.is_main.desc(), PinImage.pin_image_id.asc()),
         )
         return list(result.scalars().all())
+
+    async def delete_by_pin_id(self, pin_id: int) -> int:
+        result = await self.session.execute(
+            delete(PinImage).where(PinImage.pin_id == pin_id),
+        )
+        await self.session.flush()
+        return int(result.rowcount or 0)

--- a/app/routes/IssueRoute.py
+++ b/app/routes/IssueRoute.py
@@ -4,7 +4,7 @@ from app.core.codes import SuccessCode
 from app.core.deps import CurrentUserIdDep, IssueServiceDep
 from app.core.responses import success_response
 from app.models.enum.ToneType import ToneType
-from app.schemas.IssueDTO import CreateIssuePinRequest
+from app.schemas.IssueDTO import CreateIssuePinRequest, UpdateIssuePinRequest
 
 router = APIRouter(prefix="/issues", tags=["issue"])
 
@@ -83,6 +83,39 @@ async def get_issue_pin_reliability(
     return success_response(
         result=result.model_dump(by_alias=True, exclude_none=False),
         success_code=SuccessCode.ISSUE_PIN_RELIABILITY_GET_SUCCESS,
+    )
+
+
+@router.patch("/pin/{pin_id}")
+async def update_issue_pin(
+    pin_id: int,
+    uid: CurrentUserIdDep,
+    issue_service: IssueServiceDep,
+    background_tasks: BackgroundTasks,
+    title: str = Form(...),
+    content: str = Form(...),
+    tone: ToneType = Form(...),
+    latitude: float = Form(...),
+    longitude: float = Form(...),
+    images: list[UploadFile] = File(default=[]),
+):
+    request = UpdateIssuePinRequest(
+        title=title,
+        content=content,
+        tone=tone,
+        latitude=latitude,
+        longitude=longitude,
+    )
+    result = await issue_service.update_issue_pin(
+        uid=uid,
+        pin_id=pin_id,
+        request=request,
+        images=images,
+        background_tasks=background_tasks,
+    )
+    return success_response(
+        result=result.model_dump(by_alias=True, exclude_none=False),
+        success_code=SuccessCode.OK,
     )
 
 

--- a/app/schemas/IssueDTO.py
+++ b/app/schemas/IssueDTO.py
@@ -29,6 +29,14 @@ class CreateIssuePinRequest(BaseModel):
     longitude: float = Field(ge=-180, le=180)
 
 
+class UpdateIssuePinRequest(BaseModel):
+    title: str
+    content: str
+    tone: ToneType = ToneType.NONE
+    latitude: float = Field(ge=-90, le=90)
+    longitude: float = Field(ge=-180, le=180)
+
+
 class ImageWithLocation(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/app/services/IssueService.py
+++ b/app/services/IssueService.py
@@ -34,6 +34,7 @@ from app.schemas.IssueDTO import (
     IssuePinHomeImageItem,
     IssuePinReliabilityResponse,
     ReliabilityStatus,
+    UpdateIssuePinRequest,
 )
 from app.services.internal.issue_confidence_basis import is_failed_reliability_content
 from app.schemas.issue_pin_job import ImageSnapshot, IssuePinReliabilityJob
@@ -93,13 +94,23 @@ class IssueService:
     def _is_pin_updated(*, created_at: datetime, updated_at: datetime | None) -> bool:
         if updated_at is None:
             return False
-        return updated_at > created_at
+        # DB/driver 설정에 따라 naive/aware datetime이 혼재할 수 있어 비교 전에 정규화한다.
+        normalized_created_at = created_at
+        normalized_updated_at = updated_at
+        if normalized_created_at.tzinfo is None:
+            normalized_created_at = normalized_created_at.replace(tzinfo=ZoneInfo("UTC"))
+        if normalized_updated_at.tzinfo is None:
+            normalized_updated_at = normalized_updated_at.replace(tzinfo=ZoneInfo("UTC"))
+        return normalized_updated_at > normalized_created_at
 
     @staticmethod
-    def _user_coordinates_from_request(request: CreateIssuePinRequest) -> str:
+    def _user_coordinates_from_request(request: CreateIssuePinRequest | UpdateIssuePinRequest) -> str:
         return f"{request.latitude:.6f},{request.longitude:.6f}"
 
-    async def _resolve_user_location_address(self, request: CreateIssuePinRequest) -> str | None:
+    async def _resolve_user_location_address(
+        self,
+        request: CreateIssuePinRequest | UpdateIssuePinRequest,
+    ) -> str | None:
         resolved = await self._location_resolve_client.resolve_wgs84(
             latitude=request.latitude,
             longitude=request.longitude,
@@ -108,6 +119,34 @@ class IssueService:
             return None
         address = (resolved.address or "").strip()
         return address or None
+
+    async def _resolve_location_fields(
+        self,
+        request: CreateIssuePinRequest | UpdateIssuePinRequest,
+    ) -> tuple[int, str, str]:
+        resolved = await self._location_resolve_client.resolve_wgs84(
+            latitude=request.latitude,
+            longitude=request.longitude,
+        )
+        if resolved is None:
+            raise_validation_exception(
+                ErrorCode.VALIDATION_ERROR,
+                detail="위치를 확인할 수 없습니다. 좌표를 다시 확인해 주세요.",
+            )
+        detail_address = (resolved.address or "").strip()
+        if not detail_address:
+            raise_validation_exception(
+                ErrorCode.VALIDATION_ERROR,
+                detail="위치 주소를 확인할 수 없습니다.",
+            )
+        location_id = resolved.location_id
+        if location_id is None:
+            raise_validation_exception(
+                ErrorCode.VALIDATION_ERROR,
+                detail="위치 정보를 확인할 수 없습니다. 좌표를 다시 확인해 주세요.",
+            )
+        trimmed_address = detail_address[:150]
+        return location_id, trimmed_address, trimmed_address
 
     @staticmethod
     def _rag_hits_to_dicts(hits: list[Any]) -> list[dict[str, Any]]:
@@ -258,6 +297,10 @@ class IssueService:
         for index, upload in enumerate(images, start=1):
             raw = await upload.read()
             if not raw:
+                # multipart/form-data 에서 `images=`처럼 빈 필드가 전달되면
+                # filename 없는 0-byte 파트가 들어올 수 있다. 이 경우는 "이미지 없음"으로 처리.
+                if not (upload.filename or "").strip():
+                    continue
                 raise_validation_exception(
                     ErrorCode.VALIDATION_ERROR,
                     detail=f"이미지 파일이 비어 있습니다. (index={index})",
@@ -330,29 +373,7 @@ class IssueService:
         if user is None:
             raise_validation_exception(ErrorCode.USER_NOT_FOUND)
 
-        resolved = await self._location_resolve_client.resolve_wgs84(
-            latitude=request.latitude,
-            longitude=request.longitude,
-        )
-        if resolved is None:
-            raise_validation_exception(
-                ErrorCode.VALIDATION_ERROR,
-                detail="위치를 확인할 수 없습니다. 좌표를 다시 확인해 주세요.",
-            )
-        detail_address = (resolved.address or "").strip()
-        if not detail_address:
-            raise_validation_exception(
-                ErrorCode.VALIDATION_ERROR,
-                detail="위치 주소를 확인할 수 없습니다.",
-            )
-        detail_address = detail_address[:150]
-        location_id = resolved.location_id
-        if location_id is None:
-            raise_validation_exception(
-                ErrorCode.VALIDATION_ERROR,
-                detail="위치 정보를 확인할 수 없습니다. 좌표를 다시 확인해 주세요.",
-            )
-        user_address = detail_address
+        location_id, detail_address, user_address = await self._resolve_location_fields(request)
 
         image_snapshots = await self._snapshot_upload_images(uploads)
         user_gps = self._user_coordinates_from_request(request)
@@ -418,6 +439,114 @@ class IssueService:
             issue_pin=issue_pin,
             pin_location=pin_location,
             pin_user_nickname=user.nickname,
+            pin_images=saved_images,
+            reliability_status=ReliabilityStatus.PENDING,
+            image_upload_status=image_status,
+        )
+
+    async def update_issue_pin(
+        self,
+        *,
+        uid: str,
+        pin_id: int,
+        request: UpdateIssuePinRequest,
+        images: list[UploadFile] | None = None,
+        background_tasks: BackgroundTasks | None = None,
+    ) -> IssuePinHomeDetailResponse:
+        uploads = images or []
+        safe_title, safe_content = self._validate_create_issue_pin_payload(
+            title=request.title,
+            content=request.content,
+            images=uploads,
+        )
+        issue_pin = await self._issue_pin_repo.get_by_pin_id(pin_id)
+        if issue_pin is None or issue_pin.pin is None:
+            raise_business_exception(ErrorCode.ISSUE_NOT_FOUND)
+
+        pin = issue_pin.pin
+        if pin.pin_type != PinType.ISSUE:
+            raise_business_exception(ErrorCode.ISSUE_NOT_FOUND)
+        if pin.uid != uid:
+            raise_business_exception(ErrorCode.FORBIDDEN)
+        if issue_pin.issue_pin_state != IssuePinState.BEFORE_PROGRESS:
+            raise_validation_exception(
+                ErrorCode.VALIDATION_ERROR,
+                detail="진행 전 상태(BEFORE_PROGRESS)인 이슈 핀만 수정할 수 있습니다.",
+            )
+
+        location_id, detail_address, user_address = await self._resolve_location_fields(request)
+        image_snapshots = await self._snapshot_upload_images(uploads)
+        user_gps = self._user_coordinates_from_request(request)
+        old_s3_keys = [
+            image.pin_s3_key
+            for image in list(pin.pin_images or [])
+            if (image.pin_s3_key or "").strip()
+        ]
+
+        pin.pin_title = safe_title
+        pin.pin_content = safe_content
+        pin.tone_type = request.tone
+        await self._pin_repo.save(pin, flush_immediately=True)
+
+        pin_location = pin.pin_location
+        if pin_location is None:
+            pin_location = PinLocation(
+                pin_id=pin.pin_id,
+                location_id=location_id,
+                detail_address=detail_address,
+                pin_point=wkt_point_from_wgs84(
+                    latitude=request.latitude,
+                    longitude=request.longitude,
+                ),
+            )
+        else:
+            pin_location.location_id = location_id
+            pin_location.detail_address = detail_address
+            pin_location.pin_point = wkt_point_from_wgs84(
+                latitude=request.latitude,
+                longitude=request.longitude,
+            )
+        await self._pin_location_repo.save(pin_location, flush_immediately=True)
+
+        await self._pin_image_repo.delete_by_pin_id(pin.pin_id)
+        saved_images = await self._upload_pin_images_sync(
+            pin_id=pin.pin_id,
+            snapshots=image_snapshots,
+        )
+
+        await self._issue_pin_repo.reset_confidence(issue_pin.issue_pin_id)
+        self._background_runner.cancel(pin_id=pin.pin_id)
+        await self._pin_repo.commit()
+        if old_s3_keys:
+            deleted_count = await self._s3_util.delete_objects_best_effort(old_s3_keys)
+            logger.info(
+                "issue pin update old image S3 cleanup pin_id=%s deleted=%s requested=%s",
+                pin.pin_id,
+                deleted_count,
+                len(old_s3_keys),
+            )
+
+        self._background_runner.schedule(
+            IssuePinReliabilityJob(
+                issue_pin_id=issue_pin.issue_pin_id,
+                pin_id=pin.pin_id,
+                title=safe_title,
+                content=safe_content,
+                user_gps=user_gps,
+                user_address=user_address,
+            ),
+            background_tasks=background_tasks,
+        )
+        image_status = (
+            ImageUploadStatus.COMPLETED if image_snapshots else ImageUploadStatus.NONE
+        )
+
+        return await self._build_issue_pin_home_response(
+            uid=uid,
+            pin=pin,
+            issue_pin=issue_pin,
+            pin_location=pin_location,
+            pin_user_nickname=pin.user.nickname if pin.user is not None else None,
             pin_images=saved_images,
             reliability_status=ReliabilityStatus.PENDING,
             image_upload_status=image_status,

--- a/app/services/internal/IssuePinBackgroundRunner.py
+++ b/app/services/internal/IssuePinBackgroundRunner.py
@@ -37,6 +37,10 @@ logger = logging.getLogger(__name__)
 _RELIABILITY_PIPELINE_TASKS: set[asyncio.Task[None]] = set()
 
 
+class _StaleReliabilityJobError(RuntimeError):
+    pass
+
+
 class IssuePinBackgroundRunner:
     def __init__(
         self,
@@ -52,10 +56,52 @@ class IssuePinBackgroundRunner:
         self._s3_util = s3_util
         self._vector_store_service = vector_store_service
         self._issue_rag_planner_service = issue_rag_planner_service
+        self._latest_generation_by_pin: dict[int, int] = {}
+        self._tasks_by_pin: dict[int, set[asyncio.Task[None]]] = {}
 
     @staticmethod
     def _log_context(job: IssuePinReliabilityJob) -> str:
         return f"issue_pin_id={job.issue_pin_id} pin_id={job.pin_id}"
+
+    def _next_generation(self, pin_id: int) -> int:
+        generation = self._latest_generation_by_pin.get(pin_id, 0) + 1
+        self._latest_generation_by_pin[pin_id] = generation
+        return generation
+
+    def _assert_job_active(self, *, pin_id: int, generation: int) -> None:
+        current = self._latest_generation_by_pin.get(pin_id, 0)
+        if generation != current:
+            raise _StaleReliabilityJobError(
+                f"stale reliability job pin_id={pin_id} generation={generation} current={current}",
+            )
+
+    def _track_task(self, *, pin_id: int, task: asyncio.Task[None]) -> None:
+        tasks = self._tasks_by_pin.setdefault(pin_id, set())
+        tasks.add(task)
+
+    def _untrack_task(self, *, pin_id: int, task: asyncio.Task[None]) -> None:
+        tasks = self._tasks_by_pin.get(pin_id)
+        if tasks is None:
+            return
+        tasks.discard(task)
+        if not tasks:
+            self._tasks_by_pin.pop(pin_id, None)
+
+    def cancel(self, *, pin_id: int) -> bool:
+        generation = self._next_generation(pin_id)
+        tasks = list(self._tasks_by_pin.get(pin_id, set()))
+        cancelled = False
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+                cancelled = True
+        logger.info(
+            "Reliability cancel requested pin_id=%s generation=%s cancelled_tasks=%d",
+            pin_id,
+            generation,
+            len(tasks),
+        )
+        return cancelled
 
     def schedule(
         self,
@@ -63,25 +109,29 @@ class IssuePinBackgroundRunner:
         *,
         background_tasks: BackgroundTasks | None = None,
     ) -> None:
-        ctx = self._log_context(job)
+        generation = self._next_generation(job.pin_id)
+        ctx = f"{self._log_context(job)} generation={generation}"
         if background_tasks is not None:
-            background_tasks.add_task(self.run_reliability_job, job)
+            background_tasks.add_task(self.run_reliability_job, job, generation)
             logger.info("Reliability scheduled (BackgroundTasks) [%s]", ctx)
             return
 
         task = asyncio.create_task(
-            self.run_reliability_job(job),
-            name=f"issue_pin_reliability_{job.issue_pin_id}",
+            self.run_reliability_job(job, generation),
+            name=f"issue_pin_reliability_{job.issue_pin_id}_{generation}",
         )
         _RELIABILITY_PIPELINE_TASKS.add(task)
+        self._track_task(pin_id=job.pin_id, task=task)
         task.add_done_callback(_RELIABILITY_PIPELINE_TASKS.discard)
+        task.add_done_callback(lambda t, pid=job.pin_id: self._untrack_task(pin_id=pid, task=t))
         logger.info("Reliability scheduled (asyncio task) [%s]", ctx)
 
-    async def run_reliability_job(self, job: IssuePinReliabilityJob) -> None:
-        ctx = self._log_context(job)
+    async def run_reliability_job(self, job: IssuePinReliabilityJob, generation: int) -> None:
+        ctx = f"{self._log_context(job)} generation={generation}"
         timeout = settings.issue_pin_reliability_pipeline_timeout_seconds
         pipeline_started = time.monotonic()
         persisted = False
+        aborted = False
         logger.info(
             "Reliability pipeline job start [%s] total_timeout=%.0fs rag_timeout=%.0fs vlm_timeout=%.0fs "
             "skip_planner=%s gemini_max_attempts=%d",
@@ -93,7 +143,11 @@ class IssuePinBackgroundRunner:
             settings.issue_pin_reliability_gemini_max_attempts,
         )
         try:
-            await asyncio.wait_for(self._run_reliability_pipeline(job), timeout=timeout)
+            self._assert_job_active(pin_id=job.pin_id, generation=generation)
+            await asyncio.wait_for(
+                self._run_reliability_pipeline(job, generation),
+                timeout=timeout,
+            )
             persisted = True
             logger.info(
                 "Reliability pipeline job success [%s] elapsed=%.1fs",
@@ -108,13 +162,16 @@ class IssuePinBackgroundRunner:
                 settings.issue_pin_reliability_rag_timeout_seconds,
                 settings.issue_pin_reliability_vlm_timeout_seconds,
             )
+        except _StaleReliabilityJobError:
+            aborted = True
+            logger.info("Reliability pipeline stale-skip [%s]", ctx)
         except asyncio.CancelledError:
+            aborted = True
             logger.warning("Reliability pipeline cancelled [%s]", ctx)
-            raise
         except Exception:
             logger.exception("Reliability pipeline failed [%s]", ctx)
         finally:
-            if not persisted:
+            if not persisted and not aborted:
                 logger.warning(
                     "Reliability pipeline persist failure fallback [%s] score=0.0",
                     ctx,
@@ -127,11 +184,13 @@ class IssuePinBackgroundRunner:
                 time.monotonic() - pipeline_started,
             )
 
-    async def _run_reliability_pipeline(self, job: IssuePinReliabilityJob) -> None:
-        ctx = self._log_context(job)
+    async def _run_reliability_pipeline(self, job: IssuePinReliabilityJob, generation: int) -> None:
+        ctx = f"{self._log_context(job)} generation={generation}"
+        self._assert_job_active(pin_id=job.pin_id, generation=generation)
         user_text = format_user_text_for_pin(title=job.title, content=job.content)
 
         # --- RAG ---
+        self._assert_job_active(pin_id=job.pin_id, generation=generation)
         rag_started = time.monotonic()
         logger.info("Reliability stage=RAG start [%s]", ctx)
         try:
@@ -159,6 +218,7 @@ class IssuePinBackgroundRunner:
         )
 
         # --- S3 ---
+        self._assert_job_active(pin_id=job.pin_id, generation=generation)
         s3_started = time.monotonic()
         logger.info("Reliability stage=S3 start [%s]", ctx)
         snapshots = await self._load_snapshots_from_s3(pin_id=job.pin_id, log_context=ctx)
@@ -170,6 +230,7 @@ class IssuePinBackgroundRunner:
         )
 
         # --- EXIF ---
+        self._assert_job_active(pin_id=job.pin_id, generation=generation)
         exif_started = time.monotonic()
         logger.info("Reliability stage=EXIF start [%s] image_count=%d", ctx, len(snapshots))
         images_with_location = await self._build_vlm_inputs_from_snapshots(
@@ -184,6 +245,7 @@ class IssuePinBackgroundRunner:
         )
 
         # --- VLM ---
+        self._assert_job_active(pin_id=job.pin_id, generation=generation)
         vlm_started = time.monotonic()
         retry_opts = self._vlm_retry_options()
         logger.info(
@@ -231,6 +293,7 @@ class IssuePinBackgroundRunner:
             score=score,
             basis_markdown=basis_md,
         )
+        self._assert_job_active(pin_id=job.pin_id, generation=generation)
         logger.info("Reliability stage=PERSIST start [%s] score=%s", ctx, score)
         await self._persist_confidence(
             issue_pin_id=job.issue_pin_id,

--- a/app/utils/S3Util.py
+++ b/app/utils/S3Util.py
@@ -205,3 +205,34 @@ class S3Util:
             logger.exception("S3 바이트 다운로드 실패 key=%s err=%s", normalized_key, exc)
             raise_file_exception(ErrorCode.FILE_UPLOAD_ERROR)
 
+    async def delete_object(self, object_key: str) -> bool:
+        bucket_name = self._ensure_bucket_name()
+        normalized_key = object_key.lstrip("/")
+
+        def _delete() -> bool:
+            try:
+                self.client.delete_object(Bucket=bucket_name, Key=normalized_key)
+                return True
+            except ClientError as exc:
+                error_code = (exc.response or {}).get("Error", {}).get("Code")
+                # 이미 없는 객체는 삭제 성공으로 간주
+                if error_code in {"NoSuchKey", "404"}:
+                    logger.info("S3 삭제 대상 없음 key=%s", normalized_key)
+                    return True
+                logger.exception("S3 객체 삭제 실패 key=%s err=%s", normalized_key, exc)
+                return False
+            except BotoCoreError as exc:
+                logger.exception("S3 객체 삭제 실패 key=%s err=%s", normalized_key, exc)
+                return False
+
+        return await to_thread.run_sync(_delete)
+
+    async def delete_objects_best_effort(self, object_keys: list[str]) -> int:
+        deleted_count = 0
+        for object_key in object_keys:
+            if not object_key.strip():
+                continue
+            if await self.delete_object(object_key):
+                deleted_count += 1
+        return deleted_count
+

--- a/app/utils/S3Util.py
+++ b/app/utils/S3Util.py
@@ -228,11 +228,22 @@ class S3Util:
         return await to_thread.run_sync(_delete)
 
     async def delete_objects_best_effort(self, object_keys: list[str]) -> int:
-        deleted_count = 0
-        for object_key in object_keys:
-            if not object_key.strip():
-                continue
-            if await self.delete_object(object_key):
-                deleted_count += 1
-        return deleted_count
+        bucket_name = self._ensure_bucket_name()
+        valid_keys = [k.lstrip("/") for k in object_keys if k.strip()]
+        if not valid_keys:
+            return 0
+
+        def _delete_batch() -> int:
+            try:
+                # S3 delete_objects can handle up to 1000 keys per call
+                response = self.client.delete_objects(
+                    Bucket=bucket_name,
+                    Delete={'Objects': [{'Key': k} for k in valid_keys]}
+                )
+                return len(response.get('Deleted', []))
+            except (ClientError, BotoCoreError) as exc:
+                logger.exception("S3 batch delete failed keys=%s err=%s", valid_keys, exc)
+                return 0
+
+        return await to_thread.run_sync(_delete_batch)
 

--- a/docs/issue-pin-create-and-reliability.md
+++ b/docs/issue-pin-create-and-reliability.md
@@ -213,6 +213,25 @@ AI 미리보기. **DB 저장 없음.**
 
 ---
 
+### 4.6 `PATCH /issues/pin/{pin_id}`
+
+이슈 핀 수정.
+
+**성공 코드**: `COMMON_200`  
+**응답**: `IssuePinHomeDetailResponse`
+
+**수정 제약**
+- 작성자 본인(`pin.uid == uid`)만 수정 가능 (`COMMON_403`)
+- `issue_pin_state == BEFORE_PROGRESS`일 때만 수정 가능 (`COMMON_422`)
+- 수정 후 신뢰도는 `issue_confidence/confidence_content = NULL`로 초기화되고 재분석이 재스케줄됨
+- 이미지는 전체 교체 방식(기존 `pin_image` 삭제 후 신규 업로드)으로 처리
+
+**신뢰도 파이프라인 처리**
+- 수정 요청 시 기존 `pin_id`의 진행 중 신뢰도 작업 취소를 시도
+- 취소가 불가능한 작업(이미 실행 중 `BackgroundTasks`)은 generation 검증으로 결과 반영을 차단
+
+---
+
 ## 5. 응답 DTO 및 상태 값
 
 ### 5.1 `ReliabilityStatus`
@@ -468,12 +487,14 @@ class IssuePinReliabilityJob:
 ### 12.1 `app/routes/IssueRoute.py`
 
 - `POST /issues/pin` 추가 (`BackgroundTasks` 주입)
+- `PATCH /issues/pin/{pin_id}` 추가 (`multipart/form-data`, 이미지 전체 교체)
 - `GET /issues/pin/{issue_pin_id}` 추가
 - `GET /issues/pin/{pin_id}/reliability` 추가
 
 ### 12.2 `app/services/IssueService.py`
 
 - `create_issue_pin` 전체 구현
+- `update_issue_pin` 추가 (작성자/상태 검증, 이미지 교체, 신뢰도 초기화·재스케줄)
 - `_snapshot_upload_images`, `_upload_pin_images_sync`
 - `_build_issue_pin_home_response`, `get_issue_pin_detail`, `get_issue_pin_reliability`
 - `_derive_reliability_status`, `_derive_image_upload_status`
@@ -505,6 +526,11 @@ class IssuePinReliabilityJob:
 
 - `get_by_issue_pin_id`, `get_by_pin_id` + `selectinload` (pin, images, location, user)
 - `update_confidence`: SQL `UPDATE` (get+flush 대신)
+- `reset_confidence`: 수정 시 신뢰도 초기화
+
+### 12.7-a `app/repositories/PinImageRepo.py`
+
+- `delete_by_pin_id`: 수정 시 이미지 전체 교체를 위한 일괄 삭제
 
 ### 12.8 `app/models/IssuePin.py`
 
@@ -742,7 +768,7 @@ requirements.txt
 | 메서드 | 설명 |
 |--------|------|
 | `schedule(job, background_tasks?)` | job 큐잉 |
-| `run_reliability_job(job)` | 전체 실행 (타임아웃·finally 포함) |
+| `run_reliability_job(job, generation)` | 전체 실행 (타임아웃·취소/무효화·finally 포함) |
 
 ## 부록 B. `issue_confidence_basis` public 함수
 


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #76 

## ✨ 작업 개요
- `PATCH /issues/pin/{pin_id}` 이슈 핀 수정 API를 추가하고, 작성자 본인만 수정 가능하도록 권한 검증을 적용했습니다.
- `issue_pin_state`가 `BEFORE_PROGRESS`인 경우에만 수정 가능하도록 상태 검증을 추가했습니다.
- 수정 시 이미지를 전체 교체(기존 DB 이미지 삭제 후 신규 업로드)하고, `issue_confidence/confidence_content`를 초기화한 뒤 신뢰도 파이프라인을 재스케줄하도록 변경했습니다.
- 진행 중인 신뢰도 작업은 취소를 시도하고, 취소가 어려운 경우 generation 기반 무효화로 stale 결과 저장을 막았습니다.
- 수정 시점의 기존 이미지 S3 객체를 best-effort로 정리(delete)하도록 추가했습니다.
- `images=` 형태의 빈 multipart 입력은 “이미지 없음”으로 처리하도록 보완했습니다.
- 로컬 환경(`APP_ENV=local`)에서 INFO 로그가 출력되도록 로깅 레벨 초기화를 추가했습니다.


## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
<img width="813" height="841" alt="image" src="https://github.com/user-attachments/assets/e7ea5b49-d695-4cc6-ae9b-714cf3126711" />
