### PR TITLE
fix: Amazon Linux에서 Playwright Chromium 의존성 수동 설치

### DIFF
--- a/.platform/hooks/predeploy/10_install_playwright_chromium.sh
+++ b/.platform/hooks/predeploy/10_install_playwright_chromium.sh
@@ -22,43 +22,28 @@ if ! "${PYTHON_BIN}" -m pip show playwright >/dev/null 2>&1; then
   "${PYTHON_BIN}" -m pip install --no-cache-dir playwright
 fi
 
+run_as_root() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+# AL2023에는 xorg-x11-libs 메타 패키지가 없으므로 개별 libX* 패키지로 설치한다.
+_CHROMIUM_RPM_PACKAGES=(
+  atk at-spi2-atk at-spi2-core
+  cups-libs libdrm
+  libXcomposite libXcursor libXdamage libXext libXfixes libXi libXrandr libXScrnSaver libXtst
+  mesa-libgbm pango cairo alsa-lib libxkbcommon
+  nss nspr gtk3
+)
+
 echo "[EB][playwright] Installing Chromium system dependencies (root)..."
 if command -v dnf >/dev/null 2>&1; then
-  dnf -y install \
-    atk \
-    at-spi2-atk \
-    cups-libs \
-    libdrm \
-    libXcomposite \
-    libXdamage \
-    libXfixes \
-    libXrandr \
-    mesa-libgbm \
-    pango \
-    cairo \
-    alsa-lib \
-    libxkbcommon \
-    nss \
-    nspr \
-    xorg-x11-libs
+  run_as_root dnf -y install "${_CHROMIUM_RPM_PACKAGES[@]}"
 elif command -v yum >/dev/null 2>&1; then
-  yum -y install \
-    atk \
-    at-spi2-atk \
-    cups-libs \
-    libdrm \
-    libXcomposite \
-    libXdamage \
-    libXfixes \
-    libXrandr \
-    mesa-libgbm \
-    pango \
-    cairo \
-    alsa-lib \
-    libxkbcommon \
-    nss \
-    nspr \
-    xorg-x11-libs
+  run_as_root yum -y install "${_CHROMIUM_RPM_PACKAGES[@]}"
 else
   "${PYTHON_BIN}" -m playwright install-deps chromium
 fi


### PR DESCRIPTION
xorg-x11-libs 패키지가 Amazon Linux 2023에 없어 실패이슈 해결