### PR TITLE
refactor: 이슈 핀 등록·수정 API를 multipart request+photos 형식으로 통합

### DIFF
--- a/app/core/codes.py
+++ b/app/core/codes.py
@@ -50,6 +50,41 @@ class ErrorCode(Enum):
         "ISSUE_4222",
         "핀 생성 모델 응답을 가져올 수 없습니다. (차단 또는 형식 오류)",
     )
+    ISSUE_PIN_EDIT_VALIDATION = (
+        status.HTTP_400_BAD_REQUEST,
+        "ISSUE_PIN_EDIT_400_1",
+        "필수 요청 값 누락.",
+    )
+    ISSUE_PIN_EDIT_FAILED = (
+        status.HTTP_400_BAD_REQUEST,
+        "ISSUE_PIN_EDIT_400_2",
+        "이슈 핀 수정 API를 실행 할 수 없습니다.",
+    )
+    ISSUE_PIN_IMPORT_VALIDATION = (
+        status.HTTP_400_BAD_REQUEST,
+        "ISSUE_PIN_IMPORT_400_1",
+        "필수 요청 값 누락.",
+    )
+    ISSUE_PIN_IMPORT_FAILED = (
+        status.HTTP_400_BAD_REQUEST,
+        "ISSUE_PIN_IMPORT_400_2",
+        "이슈 핀 등록 API를 실행 할 수 없습니다.",
+    )
+    PIN_IMAGE_TOTAL_SIZE_EXCEEDED = (
+        status.HTTP_400_BAD_REQUEST,
+        "PIN_IMAGE_400_1",
+        "첨부한 사진 용량이 너무 큽니다.",
+    )
+    PIN_IMAGE_UPLOAD_FAILED = (
+        status.HTTP_400_BAD_REQUEST,
+        "PIN_IMAGE_400_2",
+        "사진 첨부에 실패했습니다.",
+    )
+    PIN_IMAGE_COUNT_EXCEEDED = (
+        status.HTTP_400_BAD_REQUEST,
+        "PIN_IMAGE_400_3",
+        "최대 사진 첨부 갯수를 초과했습니다.",
+    )
 
     # File / Upload
     FILE_NOT_FOUND = (status.HTTP_404_NOT_FOUND, "FILE_4041", "파일을 찾을 수 없습니다.")
@@ -94,6 +129,16 @@ class SuccessCode(Enum):
         status.HTTP_200_OK,
         "ISSUE_2002",
         "이슈 핀 신뢰도 조회에 성공했습니다.",
+    )
+    ISSUE_PIN_EDIT_SUCCESS = (
+        status.HTTP_200_OK,
+        "ISSUE_PIN_EDIT_200",
+        "이슈 핀 수정에 성공했습니다.",
+    )
+    ISSUE_PIN_IMPORT_SUCCESS = (
+        status.HTTP_201_CREATED,
+        "ISSUE_PIN_IMPORT_201",
+        "이슈 핀 등록에 성공했습니다.",
     )
 
     COMPLAINT_EMAIL_GENERATE_SUCCESS = (

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -106,8 +106,17 @@ class Settings(BaseSettings):
         alias="GEMINI_PIN_TEXT_MODEL",
     )
     gemini_pin_text_fallback_models: str = Field(
-        default="gemini-2.5-flash-lite,gemini-2.0-flash-lite",
+        default="gemini-2.5-flash-lite,gemini-2.5-flash",
         alias="GEMINI_PIN_TEXT_FALLBACK_MODELS",
+    )
+    # RAG 질의 재작성(Planner) — 짧은 JSON 작업이므로 flash-lite 계열 권장
+    gemini_rag_planner_model: str = Field(
+        default="gemini-2.5-flash-lite",
+        alias="GEMINI_RAG_PLANNER_MODEL",
+    )
+    gemini_rag_planner_fallback_models: str = Field(
+        default="gemini-2.5-flash",
+        alias="GEMINI_RAG_PLANNER_FALLBACK_MODELS",
     )
     gemini_embedding_model: str = Field(
         default="gemini-embedding-2",
@@ -192,7 +201,7 @@ class Settings(BaseSettings):
         alias="ISSUE_PIN_RELIABILITY_PIPELINE_TIMEOUT_SECONDS",
     )
     issue_pin_reliability_skip_rag_planner: bool = Field(
-        default=True,
+        default=False,
         alias="ISSUE_PIN_RELIABILITY_SKIP_RAG_PLANNER",
     )
     issue_pin_reliability_gemini_max_attempts: int = Field(

--- a/app/core/deps.py
+++ b/app/core/deps.py
@@ -133,8 +133,8 @@ def get_issue_rag_planner_service() -> IssueRagPlannerService:
         raise_business_exception(ErrorCode.VLM_NOT_CONFIGURED)
     return IssueRagPlannerService(
         api_key=api_key_secret.get_secret_value(),
-        model_name=settings.gemini_pin_text_model,
-        fallback_models=parse_gemini_model_list(settings.gemini_pin_text_fallback_models),
+        model_name=settings.gemini_rag_planner_model,
+        fallback_models=parse_gemini_model_list(settings.gemini_rag_planner_fallback_models),
     )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,13 @@ from app.services.internal.ai.ComplaintEmailLLMService import ComplaintEmailLLMS
 from app.services.internal.ai.VLMService import VLMService
 from app.services.internal.ai.gemini_retry import parse_gemini_model_list
 from app.services.vector_domains import DomainVectorConfig, VectorDomain
+from app.schemas.IssueDTO import (
+    CreateIssuePinMultipartRequest,
+    PinImageIsMainItem,
+    UpdateIssuePinImageUrlItem,
+    UpdateIssuePinMultipartRequest,
+)
+from app.utils.openapi_multipart import patch_multipart_json_request_field, register_pydantic_models
 from app.utils.RedisUtil import get_redis_client
 from app.utils.S3Util import S3Util
 from app.utils.vector import ensure_pgvector_extension
@@ -244,6 +251,43 @@ def custom_openapi() -> dict[str, Any]:
         routes=app.routes,
     )
     _patch_binary_media_schema(openapi_schema)
+    register_pydantic_models(
+        openapi_schema,
+        PinImageIsMainItem,
+        UpdateIssuePinImageUrlItem,
+        CreateIssuePinMultipartRequest,
+        UpdateIssuePinMultipartRequest,
+    )
+    patch_multipart_json_request_field(
+        openapi_schema,
+        body_schema_key="Body_create_issue_pin_issues_pin_post",
+        request_model=CreateIssuePinMultipartRequest,
+        description=(
+            "JSON part (Content-Type: application/json). "
+            "photos와 pinImages 길이·순서 1:1, 이미지 1장 이상이면 isMain true 정확히 1개."
+        ),
+        example={
+            "lat": 37.566535,
+            "lng": 126.977969,
+            "pinTitle": "횡단보도 신호등 고장",
+            "pinContent": "신호등이 3일째 작동하지 않습니다.",
+            "pinImages": [{"isMain": True}],
+        },
+    )
+    patch_multipart_json_request_field(
+        openapi_schema,
+        body_schema_key="Body_update_issue_pin_issues_pin__pin_id__patch",
+        request_model=UpdateIssuePinMultipartRequest,
+        description=(
+            "JSON part (Content-Type: application/json). "
+            "pinImageUrls 생략+photos 없음=기존 이미지 유지, photos 있을 때 pinImages 필수."
+        ),
+        example={
+            "pinTitle": "수정된 제목",
+            "pinContent": "수정된 본문",
+            "pinImageUrls": [{"pinImageUrl": "https://example.com/a.jpg", "isMain": True}],
+        },
+    )
     app.openapi_schema = openapi_schema
     return app.openapi_schema
 
@@ -258,3 +302,7 @@ for router in enabled_routers:
 @app.get("/health")
 def health() -> JSONResponse:
     return success_response(result={"status": "ok"}, success_code=SuccessCode.OK)
+
+@app.get("/")
+def default_route() -> JSONResponse:
+    return success_response(result={"status": "issueissyu서비스의 AI 서버입니다."}, success_code=SuccessCode.OK)

--- a/app/repositories/PinImageRepo.py
+++ b/app/repositories/PinImageRepo.py
@@ -19,6 +19,27 @@ class PinImageRepo(BaseRepo[PinImage]):
         )
         return list(result.scalars().all())
 
+    async def get_by_pin_id_and_url(self, pin_id: int, pin_s3_url: str) -> PinImage | None:
+        normalized_url = pin_s3_url.strip()
+        if not normalized_url:
+            return None
+        result = await self.session.execute(
+            select(PinImage).where(
+                PinImage.pin_id == pin_id,
+                PinImage.pin_s3_url == normalized_url,
+            ),
+        )
+        return result.scalar_one_or_none()
+
+    async def delete_by_ids(self, pin_image_ids: list[int]) -> int:
+        if not pin_image_ids:
+            return 0
+        result = await self.session.execute(
+            delete(PinImage).where(PinImage.pin_image_id.in_(pin_image_ids)),
+        )
+        await self.session.flush()
+        return int(result.rowcount or 0)
+
     async def delete_by_pin_id(self, pin_id: int) -> int:
         result = await self.session.execute(
             delete(PinImage).where(PinImage.pin_id == pin_id),

--- a/app/routes/IssueRoute.py
+++ b/app/routes/IssueRoute.py
@@ -1,10 +1,18 @@
-from fastapi import APIRouter, BackgroundTasks, File, Form, UploadFile
+from typing import Annotated
 
-from app.core.codes import SuccessCode
+from fastapi import APIRouter, BackgroundTasks, File, Form, UploadFile
+from pydantic import ValidationError
+
+from app.core.codes import ErrorCode, SuccessCode
 from app.core.deps import CurrentUserIdDep, IssueServiceDep
+from app.core.exceptions import raise_business_exception
 from app.core.responses import success_response
 from app.models.enum.ToneType import ToneType
-from app.schemas.IssueDTO import CreateIssuePinRequest, UpdateIssuePinRequest
+from app.schemas.IssueDTO import (
+    CreateIssuePinMultipartRequest,
+    CreateIssuePinRequest,
+    UpdateIssuePinMultipartRequest,
+)
 
 router = APIRouter(prefix="/issues", tags=["issue"])
 
@@ -44,29 +52,23 @@ async def create_issue_pin(
     uid: CurrentUserIdDep,
     issue_service: IssueServiceDep,
     background_tasks: BackgroundTasks,
-    title: str = Form(...),
-    content: str = Form(...),
-    tone: ToneType = Form(...),
-    latitude: float = Form(...),
-    longitude: float = Form(...),
-    images: list[UploadFile] = File(default=[]),
+    request: Annotated[str, Form(...)],
+    photos: list[UploadFile] = File(default=[]),
 ):
-    request = CreateIssuePinRequest(
-        title=title,
-        content=content,
-        tone=tone,
-        latitude=latitude,
-        longitude=longitude,
-    )
+    try:
+        body = CreateIssuePinMultipartRequest.model_validate_json(request)
+    except ValidationError:
+        raise_business_exception(ErrorCode.ISSUE_PIN_IMPORT_VALIDATION)
+
     result = await issue_service.create_issue_pin(
         uid=uid,
-        request=request,
-        images=images,
+        request=body,
+        photos=photos,
         background_tasks=background_tasks,
     )
     return success_response(
         result=result.model_dump(by_alias=True, exclude_none=False),
-        success_code=SuccessCode.CREATED,
+        success_code=SuccessCode.ISSUE_PIN_IMPORT_SUCCESS,
     )
 
 
@@ -92,30 +94,24 @@ async def update_issue_pin(
     uid: CurrentUserIdDep,
     issue_service: IssueServiceDep,
     background_tasks: BackgroundTasks,
-    title: str = Form(...),
-    content: str = Form(...),
-    tone: ToneType = Form(...),
-    latitude: float = Form(...),
-    longitude: float = Form(...),
-    images: list[UploadFile] = File(default=[]),
+    request: Annotated[str, Form(...)],
+    photos: list[UploadFile] = File(default=[]),
 ):
-    request = UpdateIssuePinRequest(
-        title=title,
-        content=content,
-        tone=tone,
-        latitude=latitude,
-        longitude=longitude,
-    )
+    try:
+        body = UpdateIssuePinMultipartRequest.model_validate_json(request)
+    except ValidationError:
+        raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_VALIDATION)
+
     result = await issue_service.update_issue_pin(
         uid=uid,
         pin_id=pin_id,
-        request=request,
-        images=images,
+        request=body,
+        photos=photos,
         background_tasks=background_tasks,
     )
     return success_response(
         result=result.model_dump(by_alias=True, exclude_none=False),
-        success_code=SuccessCode.OK,
+        success_code=SuccessCode.ISSUE_PIN_EDIT_SUCCESS,
     )
 
 

--- a/app/schemas/IssueDTO.py
+++ b/app/schemas/IssueDTO.py
@@ -29,12 +29,45 @@ class CreateIssuePinRequest(BaseModel):
     longitude: float = Field(ge=-180, le=180)
 
 
-class UpdateIssuePinRequest(BaseModel):
-    title: str
-    content: str
-    tone: ToneType = ToneType.NONE
-    latitude: float = Field(ge=-90, le=90)
-    longitude: float = Field(ge=-180, le=180)
+class UpdateIssuePinImageUrlItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    pin_image_url: str = Field(alias="pinImageUrl")
+    is_main: bool = Field(alias="isMain")
+
+
+class PinImageIsMainItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    is_main: bool = Field(alias="isMain")
+
+
+UpdateIssuePinNewImageItem = PinImageIsMainItem
+
+
+class CreateIssuePinMultipartRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    lat: float = Field(ge=-90, le=90)
+    lng: float = Field(ge=-180, le=180)
+    pin_title: str = Field(alias="pinTitle")
+    pin_content: str = Field(alias="pinContent")
+    pin_images: list[PinImageIsMainItem] = Field(alias="pinImages")
+
+
+class UpdateIssuePinMultipartRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    pin_title: str = Field(alias="pinTitle")
+    pin_content: str = Field(alias="pinContent")
+    pin_image_urls: list[UpdateIssuePinImageUrlItem] | None = Field(
+        default=None,
+        alias="pinImageUrls",
+    )
+    pin_images: list[PinImageIsMainItem] | None = Field(
+        default=None,
+        alias="pinImages",
+    )
 
 
 class ImageWithLocation(BaseModel):

--- a/app/services/IssueService.py
+++ b/app/services/IssueService.py
@@ -392,6 +392,14 @@ class IssueService:
         if request.pin_image_urls is None:
             kept_specs = [(img, img.is_main) for img in existing_images]
         else:
+            url_to_image: dict[str, PinImage] = {}
+            for img in existing_images:
+                if img.pin_id != pin_id:
+                    raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_VALIDATION)
+                normalized_url = (img.pin_s3_url or "").strip()
+                if normalized_url:
+                    url_to_image[normalized_url] = img
+
             seen_urls: set[str] = set()
             seen_ids: set[int] = set()
             for item in request.pin_image_urls:
@@ -399,7 +407,7 @@ class IssueService:
                 if not url or url in seen_urls:
                     raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_VALIDATION)
                 seen_urls.add(url)
-                row = await self._pin_image_repo.get_by_pin_id_and_url(pin_id, url)
+                row = url_to_image.get(url)
                 if row is None:
                     raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_VALIDATION)
                 if row.pin_image_id in seen_ids:

--- a/app/services/IssueService.py
+++ b/app/services/IssueService.py
@@ -515,6 +515,47 @@ class IssueService:
         saved_images.extend(new_rows)
         return saved_images, new_s3_keys
 
+    async def _cleanup_removed_pin_images_best_effort(
+        self,
+        *,
+        pin_id: int,
+        removed_s3_keys: tuple[str, ...],
+    ) -> None:
+        """commit 성공 후 제거된 핀 이미지 S3 객체를 best-effort로 삭제한다.
+
+        DB 커밋 이후에만 호출해야 한다. 실패해도 API 응답은 성공으로 유지하고
+        로그만 남긴다(고아 객체는 운영 모니터링·별도 배치 정리 대상).
+        """
+        if not removed_s3_keys:
+            return
+        requested = len(removed_s3_keys)
+        try:
+            deleted_count = await self._s3_util.delete_objects_best_effort(
+                list(removed_s3_keys),
+            )
+        except Exception:
+            logger.exception(
+                "issue pin update removed image S3 cleanup failed pin_id=%s requested=%s",
+                pin_id,
+                requested,
+            )
+            return
+
+        if deleted_count < requested:
+            logger.warning(
+                "issue pin update removed image S3 cleanup incomplete pin_id=%s deleted=%s requested=%s",
+                pin_id,
+                deleted_count,
+                requested,
+            )
+        else:
+            logger.info(
+                "issue pin update removed image S3 cleanup pin_id=%s deleted=%s requested=%s",
+                pin_id,
+                deleted_count,
+                requested,
+            )
+
     @staticmethod
     def _user_gps_from_pin_location(pin_location: PinLocation | None) -> str:
         if pin_location is None:
@@ -705,6 +746,9 @@ class IssueService:
                     plan=image_plan,
                 )
 
+            user_gps = self._user_gps_from_pin_location(pin_location)
+            user_address = (pin_location.detail_address or "").strip() or None
+
             await self._issue_pin_repo.reset_confidence(issue_pin.issue_pin_id)
             await self._background_runner.cancel(pin_id=pin.pin_id)
             await self._pin_repo.commit()
@@ -720,19 +764,10 @@ class IssueService:
             logger.exception("issue pin update failed pin_id=%s", pin.pin_id)
             raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_FAILED)
 
-        user_gps = self._user_gps_from_pin_location(pin_location)
-        user_address = (pin_location.detail_address or "").strip() or None
-
-        if image_plan.removed_s3_keys:
-            deleted_count = await self._s3_util.delete_objects_best_effort(
-                list(image_plan.removed_s3_keys),
-            )
-            logger.info(
-                "issue pin update removed image S3 cleanup pin_id=%s deleted=%s requested=%s",
-                pin.pin_id,
-                deleted_count,
-                len(image_plan.removed_s3_keys),
-            )
+        await self._cleanup_removed_pin_images_best_effort(
+            pin_id=pin.pin_id,
+            removed_s3_keys=image_plan.removed_s3_keys,
+        )
 
         await self._background_runner.schedule(
             IssuePinReliabilityJob(

--- a/app/services/IssueService.py
+++ b/app/services/IssueService.py
@@ -458,17 +458,24 @@ class IssueService:
             return [], []
 
         uploaded_keys: list[str] = []
+
+        async def upload_and_track(snap: ImageSnapshot) -> dict[str, str]:
+            uploaded = await self._upload_snapshot_to_s3(snap)
+            uploaded_keys.append(uploaded["key"])
+            return uploaded
+
         try:
             uploaded_list = await asyncio.gather(
-                *[self._upload_snapshot_to_s3(snap) for snap, _ in new_specs],
+                *[upload_and_track(snap) for snap, _ in new_specs],
             )
         except Exception:
-            logger.exception("issue pin update image S3 upload failed pin_id=%s", pin_id)
+            if uploaded_keys:
+                await self._s3_util.delete_objects_best_effort(uploaded_keys)
+            logger.exception("issue pin image S3 upload failed pin_id=%s", pin_id)
             raise_business_exception(ErrorCode.PIN_IMAGE_UPLOAD_FAILED)
 
         saved: list[PinImage] = []
         for (snap, is_main), uploaded in zip(new_specs, uploaded_list, strict=True):
-            uploaded_keys.append(uploaded["key"])
             pin_image = PinImage(
                 pin_id=pin_id,
                 pin_s3_key=uploaded["key"],

--- a/app/services/IssueService.py
+++ b/app/services/IssueService.py
@@ -483,7 +483,7 @@ class IssueService:
         *,
         pin_id: int,
         plan: _UpdatePinImagePlan,
-    ) -> list[PinImage]:
+    ) -> tuple[list[PinImage], list[str]]:
         new_rows, new_s3_keys = await self._upload_new_pin_images_with_is_main(
             pin_id=pin_id,
             new_specs=plan.new,
@@ -513,7 +513,7 @@ class IssueService:
 
         saved_images = [row for row, _ in plan.kept]
         saved_images.extend(new_rows)
-        return saved_images
+        return saved_images, new_s3_keys
 
     @staticmethod
     def _user_gps_from_pin_location(pin_location: PinLocation | None) -> str:
@@ -689,31 +689,39 @@ class IssueService:
             photos=uploads,
         )
 
-        if safe_title != pin.pin_title or safe_content != pin.pin_content:
-            pin.pin_title = safe_title
-            pin.pin_content = safe_content
-            await self._pin_repo.save(pin, flush_immediately=True)
-
+        uploaded_keys: list[str] = []
         saved_images: list[PinImage]
-        if image_plan.images_unchanged:
-            saved_images = existing_images
-        else:
-            saved_images = await self._sync_pin_images_after_update(
-                pin_id=pin.pin_id,
-                plan=image_plan,
-            )
+        try:
+            if safe_title != pin.pin_title or safe_content != pin.pin_content:
+                pin.pin_title = safe_title
+                pin.pin_content = safe_content
+                await self._pin_repo.save(pin, flush_immediately=True)
+
+            if image_plan.images_unchanged:
+                saved_images = existing_images
+            else:
+                saved_images, uploaded_keys = await self._sync_pin_images_after_update(
+                    pin_id=pin.pin_id,
+                    plan=image_plan,
+                )
+
+            await self._issue_pin_repo.reset_confidence(issue_pin.issue_pin_id)
+            await self._background_runner.cancel(pin_id=pin.pin_id)
+            await self._pin_repo.commit()
+        except BusinessException:
+            await self._pin_repo.rollback()
+            if uploaded_keys:
+                await self._s3_util.delete_objects_best_effort(uploaded_keys)
+            raise
+        except Exception:
+            await self._pin_repo.rollback()
+            if uploaded_keys:
+                await self._s3_util.delete_objects_best_effort(uploaded_keys)
+            logger.exception("issue pin update failed pin_id=%s", pin.pin_id)
+            raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_FAILED)
 
         user_gps = self._user_gps_from_pin_location(pin_location)
         user_address = (pin_location.detail_address or "").strip() or None
-
-        await self._issue_pin_repo.reset_confidence(issue_pin.issue_pin_id)
-        await self._background_runner.cancel(pin_id=pin.pin_id)
-        try:
-            await self._pin_repo.commit()
-        except Exception:
-            await self._pin_repo.rollback()
-            logger.exception("issue pin update commit failed pin_id=%s", pin.pin_id)
-            raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_FAILED)
 
         if image_plan.removed_s3_keys:
             deleted_count = await self._s3_util.delete_objects_best_effort(

--- a/app/services/IssueService.py
+++ b/app/services/IssueService.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import mimetypes
+from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -11,13 +13,18 @@ from fastapi import BackgroundTasks, UploadFile
 
 from app.core.config import settings
 from app.core.codes import ErrorCode
-from app.core.exceptions import raise_business_exception, raise_file_exception, raise_validation_exception
+from app.core.exceptions import (
+    BusinessException,
+    raise_business_exception,
+    raise_validation_exception,
+)
 from app.models.IssuePin import IssuePin
 from app.models.Pin import Pin
 from app.models.PinImage import PinImage
 from app.models.PinLocation import PinLocation
 from app.models.enum.IssuePinState import IssuePinState
 from app.models.enum.PinType import PinType
+from app.models.enum.ToneType import ToneType
 from app.repositories.CommunityRepo import CommunityRepo
 from app.repositories.IssuePinRepo import IssuePinRepo
 from app.repositories.PinLikeRepo import PinLikeRepo
@@ -27,6 +34,7 @@ from app.repositories.PinRepo import PinRepo
 from app.repositories.UserRepo import UserRepo
 from app.utils.S3Util import S3Util
 from app.schemas.IssueDTO import (
+    CreateIssuePinMultipartRequest,
     CreateIssuePinRequest,
     ImageUploadStatus,
     IssueAnalysisResult,
@@ -34,7 +42,7 @@ from app.schemas.IssueDTO import (
     IssuePinHomeImageItem,
     IssuePinReliabilityResponse,
     ReliabilityStatus,
-    UpdateIssuePinRequest,
+    UpdateIssuePinMultipartRequest,
 )
 from app.services.internal.issue_confidence_basis import is_failed_reliability_content
 from app.schemas.issue_pin_job import ImageSnapshot, IssuePinReliabilityJob
@@ -45,11 +53,20 @@ from app.services.internal.ai.IssueRagPlannerService import IssueRagPlannerServi
 from app.services.internal.geo.LocationResolveClient import LocationResolveClient
 from app.services.prompts import build_issue_pin_prompt_from_pipeline_bundle
 from app.services.vector_domains import VectorDomain
-from app.utils.geo import wkt_point_from_wgs84
+from app.utils.geo import user_gps_from_wgs84, wgs84_from_pin_point, wkt_point_from_wgs84
 
 logger = logging.getLogger(__name__)
 SINGLE_RETRIEVAL_TOP_K = 5
 S3_ISSUE_IMAGE_PREFIX = "issueimage"
+MAX_PIN_IMAGE_TOTAL_BYTES = 50 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class _UpdatePinImagePlan:
+    images_unchanged: bool
+    kept: tuple[tuple[PinImage, bool], ...]
+    new: tuple[tuple[ImageSnapshot, bool], ...]
+    removed_s3_keys: tuple[str, ...]
 
 
 class IssueService:
@@ -104,12 +121,15 @@ class IssueService:
         return normalized_updated_at > normalized_created_at
 
     @staticmethod
-    def _user_coordinates_from_request(request: CreateIssuePinRequest | UpdateIssuePinRequest) -> str:
-        return f"{request.latitude:.6f},{request.longitude:.6f}"
+    def _user_coordinates_from_request(request: CreateIssuePinRequest) -> str:
+        return user_gps_from_wgs84(
+            latitude=request.latitude,
+            longitude=request.longitude,
+        )
 
     async def _resolve_user_location_address(
         self,
-        request: CreateIssuePinRequest | UpdateIssuePinRequest,
+        request: CreateIssuePinRequest,
     ) -> str | None:
         resolved = await self._location_resolve_client.resolve_wgs84(
             latitude=request.latitude,
@@ -122,29 +142,48 @@ class IssueService:
 
     async def _resolve_location_fields(
         self,
-        request: CreateIssuePinRequest | UpdateIssuePinRequest,
+        request: CreateIssuePinRequest,
     ) -> tuple[int, str, str]:
-        resolved = await self._location_resolve_client.resolve_wgs84(
+        return await self._resolve_location_fields_from_coords(
             latitude=request.latitude,
             longitude=request.longitude,
+            failure_error=ErrorCode.VALIDATION_ERROR,
+        )
+
+    async def _resolve_location_fields_from_coords(
+        self,
+        *,
+        latitude: float,
+        longitude: float,
+        failure_error: ErrorCode = ErrorCode.ISSUE_PIN_IMPORT_FAILED,
+    ) -> tuple[int, str, str]:
+        resolved = await self._location_resolve_client.resolve_wgs84(
+            latitude=latitude,
+            longitude=longitude,
         )
         if resolved is None:
-            raise_validation_exception(
-                ErrorCode.VALIDATION_ERROR,
-                detail="위치를 확인할 수 없습니다. 좌표를 다시 확인해 주세요.",
-            )
+            if failure_error == ErrorCode.VALIDATION_ERROR:
+                raise_validation_exception(
+                    failure_error,
+                    detail="위치를 확인할 수 없습니다. 좌표를 다시 확인해 주세요.",
+                )
+            raise_business_exception(failure_error)
         detail_address = (resolved.address or "").strip()
         if not detail_address:
-            raise_validation_exception(
-                ErrorCode.VALIDATION_ERROR,
-                detail="위치 주소를 확인할 수 없습니다.",
-            )
+            if failure_error == ErrorCode.VALIDATION_ERROR:
+                raise_validation_exception(
+                    failure_error,
+                    detail="위치 주소를 확인할 수 없습니다.",
+                )
+            raise_business_exception(failure_error)
         location_id = resolved.location_id
         if location_id is None:
-            raise_validation_exception(
-                ErrorCode.VALIDATION_ERROR,
-                detail="위치 정보를 확인할 수 없습니다. 좌표를 다시 확인해 주세요.",
-            )
+            if failure_error == ErrorCode.VALIDATION_ERROR:
+                raise_validation_exception(
+                    failure_error,
+                    detail="위치 정보를 확인할 수 없습니다. 좌표를 다시 확인해 주세요.",
+                )
+            raise_business_exception(failure_error)
         trimmed_address = detail_address[:150]
         return location_id, trimmed_address, trimmed_address
 
@@ -261,62 +300,6 @@ class IssueService:
             content=pin_body,
         )
 
-    @staticmethod
-    def _validate_create_issue_pin_payload(
-        *,
-        title: str,
-        content: str,
-        images: list[UploadFile],
-    ) -> tuple[str, str]:
-        safe_title = title.strip()
-        safe_content = content.strip()
-        if not safe_title:
-            raise_validation_exception(ErrorCode.VALIDATION_ERROR, detail="제목을 입력해 주세요.")
-        if not safe_content:
-            raise_validation_exception(ErrorCode.VALIDATION_ERROR, detail="본문을 입력해 주세요.")
-        if len(safe_title) > settings.pin_title_max_length:
-            raise_validation_exception(
-                ErrorCode.VALIDATION_ERROR,
-                detail=f"제목은 {settings.pin_title_max_length}자 이하여야 합니다.",
-            )
-        if len(safe_content) > settings.pin_content_max_length:
-            raise_validation_exception(
-                ErrorCode.VALIDATION_ERROR,
-                detail=f"본문은 {settings.pin_content_max_length}자 이하여야 합니다.",
-            )
-        if len(images) > settings.issue_pin_max_images:
-            raise_validation_exception(
-                ErrorCode.VALIDATION_ERROR,
-                detail=f"이미지는 최대 {settings.issue_pin_max_images}장까지 업로드할 수 있습니다.",
-            )
-        return safe_title, safe_content
-
-    @staticmethod
-    async def _snapshot_upload_images(images: list[UploadFile]) -> tuple[ImageSnapshot, ...]:
-        snapshots: list[ImageSnapshot] = []
-        for index, upload in enumerate(images, start=1):
-            raw = await upload.read()
-            if not raw:
-                # multipart/form-data 에서 `images=`처럼 빈 필드가 전달되면
-                # filename 없는 0-byte 파트가 들어올 수 있다. 이 경우는 "이미지 없음"으로 처리.
-                if not (upload.filename or "").strip():
-                    continue
-                raise_validation_exception(
-                    ErrorCode.VALIDATION_ERROR,
-                    detail=f"이미지 파일이 비어 있습니다. (index={index})",
-                )
-            mime = (upload.content_type or "").split(";")[0].strip().lower()
-            if not mime:
-                guessed, _ = mimetypes.guess_type(upload.filename or "")
-                mime = (guessed or "").split(";")[0].strip().lower()
-            if not mime.startswith("image/"):
-                raise_file_exception(ErrorCode.FILE_TYPE_NOT_SUPPORTED)
-            name = upload.filename or f"image_{index}.jpg"
-            snapshots.append(
-                ImageSnapshot(data=raw, content_type=mime, filename=name),
-            )
-        return tuple(snapshots)
-
     async def _upload_snapshot_to_s3(self, snap: ImageSnapshot) -> dict[str, str]:
         return await self._s3_util.upload_bytes(
             snap.data,
@@ -325,98 +308,320 @@ class IssueService:
             prefix=S3_ISSUE_IMAGE_PREFIX,
         )
 
-    async def _upload_pin_images_sync(
+    @staticmethod
+    def _validate_pin_text(
+        *,
+        pin_title: str,
+        pin_content: str,
+        validation_error: ErrorCode,
+    ) -> tuple[str, str]:
+        safe_title = pin_title.strip()
+        safe_content = pin_content.strip()
+        if not safe_title or not safe_content:
+            raise_business_exception(validation_error)
+        if len(safe_title) > settings.pin_title_max_length:
+            raise_business_exception(validation_error)
+        if len(safe_content) > settings.pin_content_max_length:
+            raise_business_exception(validation_error)
+        return safe_title, safe_content
+
+    @staticmethod
+    def _validate_update_issue_pin_text(*, pin_title: str, pin_content: str) -> tuple[str, str]:
+        return IssueService._validate_pin_text(
+            pin_title=pin_title,
+            pin_content=pin_content,
+            validation_error=ErrorCode.ISSUE_PIN_EDIT_VALIDATION,
+        )
+
+    @staticmethod
+    def _validate_pin_image_main_flags(
+        *main_flags: bool,
+        error_code: ErrorCode = ErrorCode.ISSUE_PIN_EDIT_VALIDATION,
+    ) -> None:
+        if not main_flags:
+            return
+        main_count = sum(1 for flag in main_flags if flag)
+        if main_count != 1:
+            raise_business_exception(error_code)
+
+    @staticmethod
+    async def _snapshot_update_photos(photos: list[UploadFile]) -> tuple[ImageSnapshot, ...]:
+        snapshots: list[ImageSnapshot] = []
+        total_bytes = 0
+        for index, upload in enumerate(photos, start=1):
+            raw = await upload.read()
+            if not raw:
+                if not (upload.filename or "").strip():
+                    continue
+                raise_business_exception(ErrorCode.PIN_IMAGE_UPLOAD_FAILED)
+            extension = Path(upload.filename or "").suffix.lower()
+            if extension not in S3Util.ALLOWED_IMAGE_EXTENSIONS:
+                raise_business_exception(ErrorCode.PIN_IMAGE_UPLOAD_FAILED)
+            mime = (upload.content_type or "").split(";")[0].strip().lower()
+            if not mime:
+                guessed, _ = mimetypes.guess_type(upload.filename or "")
+                mime = (guessed or "").split(";")[0].strip().lower()
+            if not mime.startswith("image/"):
+                raise_business_exception(ErrorCode.PIN_IMAGE_UPLOAD_FAILED)
+            total_bytes += len(raw)
+            if total_bytes > MAX_PIN_IMAGE_TOTAL_BYTES:
+                raise_business_exception(ErrorCode.PIN_IMAGE_TOTAL_SIZE_EXCEEDED)
+            name = upload.filename or f"image_{index}.jpg"
+            snapshots.append(
+                ImageSnapshot(data=raw, content_type=mime, filename=name),
+            )
+        return tuple(snapshots)
+
+    async def _build_update_pin_image_plan(
         self,
         *,
         pin_id: int,
-        snapshots: tuple[ImageSnapshot, ...],
-    ) -> list[PinImage]:
-        """S3 업로드는 병렬(asyncio.gather), DB 저장은 동일 세션에서 순차 처리."""
-        if not snapshots:
-            return []
+        existing_images: list[PinImage],
+        request: UpdateIssuePinMultipartRequest,
+        photos: list[UploadFile],
+    ) -> _UpdatePinImagePlan:
+        if request.pin_image_urls is None and not photos:
+            return _UpdatePinImagePlan(
+                images_unchanged=True,
+                kept=tuple(),
+                new=tuple(),
+                removed_s3_keys=tuple(),
+            )
 
+        kept_specs: list[tuple[PinImage, bool]] = []
+        if request.pin_image_urls is None:
+            kept_specs = [(img, img.is_main) for img in existing_images]
+        else:
+            seen_urls: set[str] = set()
+            seen_ids: set[int] = set()
+            for item in request.pin_image_urls:
+                url = item.pin_image_url.strip()
+                if not url or url in seen_urls:
+                    raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_VALIDATION)
+                seen_urls.add(url)
+                row = await self._pin_image_repo.get_by_pin_id_and_url(pin_id, url)
+                if row is None:
+                    raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_VALIDATION)
+                if row.pin_image_id in seen_ids:
+                    raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_VALIDATION)
+                seen_ids.add(row.pin_image_id)
+                kept_specs.append((row, item.is_main))
+
+        if request.pin_images and not photos:
+            raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_VALIDATION)
+
+        new_specs: list[tuple[ImageSnapshot, bool]] = []
+        if photos:
+            pin_images_meta = request.pin_images
+            if pin_images_meta is None:
+                raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_VALIDATION)
+            snapshots = await self._snapshot_update_photos(photos)
+            if not snapshots:
+                raise_business_exception(ErrorCode.PIN_IMAGE_UPLOAD_FAILED)
+            if len(snapshots) != len(pin_images_meta):
+                raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_VALIDATION)
+            new_specs = [
+                (snapshots[index], pin_images_meta[index].is_main)
+                for index in range(len(snapshots))
+            ]
+
+        total_count = len(kept_specs) + len(new_specs)
+        if total_count > settings.issue_pin_max_images:
+            raise_business_exception(ErrorCode.PIN_IMAGE_COUNT_EXCEEDED)
+
+        self._validate_pin_image_main_flags(
+            *[is_main for _, is_main in kept_specs],
+            *[is_main for _, is_main in new_specs],
+        )
+
+        kept_ids = {row.pin_image_id for row, _ in kept_specs}
+        removed_s3_keys = tuple(
+            (img.pin_s3_key or "").strip()
+            for img in existing_images
+            if img.pin_image_id not in kept_ids and (img.pin_s3_key or "").strip()
+        )
+
+        return _UpdatePinImagePlan(
+            images_unchanged=False,
+            kept=tuple(kept_specs),
+            new=tuple(new_specs),
+            removed_s3_keys=removed_s3_keys,
+        )
+
+    async def _upload_new_pin_images_with_is_main(
+        self,
+        *,
+        pin_id: int,
+        new_specs: tuple[tuple[ImageSnapshot, bool], ...],
+    ) -> tuple[list[PinImage], list[str]]:
+        if not new_specs:
+            return [], []
+
+        uploaded_keys: list[str] = []
         try:
             uploaded_list = await asyncio.gather(
-                *[self._upload_snapshot_to_s3(snap) for snap in snapshots],
+                *[self._upload_snapshot_to_s3(snap) for snap, _ in new_specs],
             )
         except Exception:
-            logger.exception("issue pin image S3 upload failed pin_id=%s", pin_id)
-            raise_file_exception(ErrorCode.FILE_UPLOAD_ERROR)
+            logger.exception("issue pin update image S3 upload failed pin_id=%s", pin_id)
+            raise_business_exception(ErrorCode.PIN_IMAGE_UPLOAD_FAILED)
 
         saved: list[PinImage] = []
-        for index, (snap, uploaded) in enumerate(zip(snapshots, uploaded_list, strict=True)):
+        for (snap, is_main), uploaded in zip(new_specs, uploaded_list, strict=True):
+            uploaded_keys.append(uploaded["key"])
             pin_image = PinImage(
                 pin_id=pin_id,
                 pin_s3_key=uploaded["key"],
                 pin_s3_url=uploaded["url"],
-                is_main=index == 0,
+                is_main=is_main,
             )
-            await self._pin_image_repo.save(pin_image, flush_immediately=True)
             saved.append(pin_image)
-        return saved
+        return saved, uploaded_keys
+
+    async def _sync_pin_images_after_update(
+        self,
+        *,
+        pin_id: int,
+        plan: _UpdatePinImagePlan,
+    ) -> list[PinImage]:
+        new_rows, new_s3_keys = await self._upload_new_pin_images_with_is_main(
+            pin_id=pin_id,
+            new_specs=plan.new,
+        )
+        try:
+            kept_ids = {row.pin_image_id for row, _ in plan.kept}
+            all_existing = await self._pin_image_repo.list_by_pin_id(pin_id)
+            remove_ids = [
+                img.pin_image_id
+                for img in all_existing
+                if img.pin_image_id not in kept_ids
+            ]
+            if remove_ids:
+                await self._pin_image_repo.delete_by_ids(remove_ids)
+
+            for row, is_main in plan.kept:
+                row.is_main = is_main
+                await self._pin_image_repo.save(row, flush_immediately=True)
+
+            for pin_image in new_rows:
+                await self._pin_image_repo.save(pin_image, flush_immediately=True)
+        except Exception:
+            if new_s3_keys:
+                await self._s3_util.delete_objects_best_effort(new_s3_keys)
+            logger.exception("issue pin update image DB sync failed pin_id=%s", pin_id)
+            raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_FAILED)
+
+        saved_images = [row for row, _ in plan.kept]
+        saved_images.extend(new_rows)
+        return saved_images
+
+    @staticmethod
+    def _user_gps_from_pin_location(pin_location: PinLocation | None) -> str:
+        if pin_location is None:
+            raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_FAILED)
+        latitude, longitude = wgs84_from_pin_point(pin_location.pin_point)
+        return user_gps_from_wgs84(latitude=latitude, longitude=longitude)
 
     async def create_issue_pin(
         self,
         *,
         uid: str,
-        request: CreateIssuePinRequest,
-        images: list[UploadFile] | None = None,
+        request: CreateIssuePinMultipartRequest,
+        photos: list[UploadFile] | None = None,
         background_tasks: BackgroundTasks | None = None,
     ) -> IssuePinHomeDetailResponse:
-        uploads = images or []
-        safe_title, safe_content = self._validate_create_issue_pin_payload(
-            title=request.title,
-            content=request.content,
-            images=uploads,
+        uploads = photos or []
+        safe_title, safe_content = self._validate_pin_text(
+            pin_title=request.pin_title,
+            pin_content=request.pin_content,
+            validation_error=ErrorCode.ISSUE_PIN_IMPORT_VALIDATION,
         )
+        if len(uploads) > settings.issue_pin_max_images:
+            raise_business_exception(ErrorCode.PIN_IMAGE_COUNT_EXCEEDED)
+        if len(uploads) != len(request.pin_images):
+            raise_business_exception(ErrorCode.ISSUE_PIN_IMPORT_VALIDATION)
+        self._validate_pin_image_main_flags(
+            *[item.is_main for item in request.pin_images],
+            error_code=ErrorCode.ISSUE_PIN_IMPORT_VALIDATION,
+        )
+
         user = await self._user_repo.get_by_uid(uid)
         if user is None:
-            raise_validation_exception(ErrorCode.USER_NOT_FOUND)
+            raise_business_exception(ErrorCode.USER_NOT_FOUND)
 
-        location_id, detail_address, user_address = await self._resolve_location_fields(request)
+        location_id, detail_address, user_address = await self._resolve_location_fields_from_coords(
+            latitude=request.lat,
+            longitude=request.lng,
+        )
+        user_gps = user_gps_from_wgs84(latitude=request.lat, longitude=request.lng)
 
-        image_snapshots = await self._snapshot_upload_images(uploads)
-        user_gps = self._user_coordinates_from_request(request)
+        image_specs: tuple[tuple[ImageSnapshot, bool], ...] = ()
+        if uploads:
+            snapshots = await self._snapshot_update_photos(uploads)
+            if len(snapshots) != len(request.pin_images):
+                raise_business_exception(ErrorCode.ISSUE_PIN_IMPORT_VALIDATION)
+            image_specs = tuple(
+                (snapshots[index], request.pin_images[index].is_main)
+                for index in range(len(snapshots))
+            )
 
         pin = Pin(
             uid=uid,
             pin_type=PinType.ISSUE,
             pin_title=safe_title,
             pin_content=safe_content,
-            tone_type=request.tone,
+            tone_type=ToneType.NONE,
             like_count=0,
             view_count=0,
         )
-        await self._pin_repo.save(pin, flush_immediately=True)
 
-        issue_pin = IssuePin(
-            issue_pin_state=IssuePinState.BEFORE_PROGRESS,
-            petition_count=0,
-            pin_id=pin.pin_id,
-            issue_confidence=None,
-            confidence_content=None,
-        )
-        await self._issue_pin_repo.save(issue_pin, flush_immediately=True)
-
-        pin_location = PinLocation(
-            pin_id=pin.pin_id,
-            location_id=location_id,
-            detail_address=detail_address,
-            pin_point=wkt_point_from_wgs84(
-                latitude=request.latitude,
-                longitude=request.longitude,
-            ),
-        )
-        await self._pin_location_repo.save(pin_location, flush_immediately=True)
-
+        uploaded_keys: list[str] = []
         saved_images: list[PinImage] = []
-        if image_snapshots:
-            saved_images = await self._upload_pin_images_sync(
-                pin_id=pin.pin_id,
-                snapshots=image_snapshots,
-            )
+        issue_pin: IssuePin
+        pin_location: PinLocation
+        try:
+            await self._pin_repo.save(pin, flush_immediately=True)
 
-        await self._pin_repo.commit()
+            issue_pin = IssuePin(
+                issue_pin_state=IssuePinState.BEFORE_PROGRESS,
+                petition_count=0,
+                pin_id=pin.pin_id,
+                issue_confidence=None,
+                confidence_content=None,
+            )
+            await self._issue_pin_repo.save(issue_pin, flush_immediately=True)
+
+            pin_location = PinLocation(
+                pin_id=pin.pin_id,
+                location_id=location_id,
+                detail_address=detail_address,
+                pin_point=wkt_point_from_wgs84(
+                    latitude=request.lat,
+                    longitude=request.lng,
+                ),
+            )
+            await self._pin_location_repo.save(pin_location, flush_immediately=True)
+
+            if image_specs:
+                saved_images, uploaded_keys = await self._upload_new_pin_images_with_is_main(
+                    pin_id=pin.pin_id,
+                    new_specs=image_specs,
+                )
+                for pin_image in saved_images:
+                    await self._pin_image_repo.save(pin_image, flush_immediately=True)
+
+            await self._pin_repo.commit()
+        except BusinessException:
+            await self._pin_repo.rollback()
+            if uploaded_keys:
+                await self._s3_util.delete_objects_best_effort(uploaded_keys)
+            raise
+        except Exception:
+            await self._pin_repo.rollback()
+            if uploaded_keys:
+                await self._s3_util.delete_objects_best_effort(uploaded_keys)
+            logger.exception("issue pin create commit failed uid=%s", uid)
+            raise_business_exception(ErrorCode.ISSUE_PIN_IMPORT_FAILED)
 
         await self._background_runner.schedule(
             IssuePinReliabilityJob(
@@ -430,9 +635,7 @@ class IssueService:
             background_tasks=background_tasks,
         )
 
-        image_status = (
-            ImageUploadStatus.COMPLETED if image_snapshots else ImageUploadStatus.NONE
-        )
+        image_status = ImageUploadStatus.COMPLETED if saved_images else ImageUploadStatus.NONE
         return await self._build_issue_pin_home_response(
             uid=uid,
             pin=pin,
@@ -449,15 +652,18 @@ class IssueService:
         *,
         uid: str,
         pin_id: int,
-        request: UpdateIssuePinRequest,
-        images: list[UploadFile] | None = None,
+        request: UpdateIssuePinMultipartRequest,
+        photos: list[UploadFile] | None = None,
         background_tasks: BackgroundTasks | None = None,
     ) -> IssuePinHomeDetailResponse:
-        uploads = images or []
-        safe_title, safe_content = self._validate_create_issue_pin_payload(
-            title=request.title,
-            content=request.content,
-            images=uploads,
+        uploads = photos or []
+        user = await self._user_repo.get_by_uid(uid)
+        if user is None:
+            raise_business_exception(ErrorCode.USER_NOT_FOUND)
+
+        safe_title, safe_content = self._validate_update_issue_pin_text(
+            pin_title=request.pin_title,
+            pin_content=request.pin_content,
         )
         issue_pin = await self._issue_pin_repo.get_by_pin_id(pin_id)
         if issue_pin is None or issue_pin.pin is None:
@@ -469,62 +675,55 @@ class IssueService:
         if pin.uid != uid:
             raise_business_exception(ErrorCode.FORBIDDEN)
         if issue_pin.issue_pin_state != IssuePinState.BEFORE_PROGRESS:
-            raise_validation_exception(
-                ErrorCode.VALIDATION_ERROR,
-                detail="진행 전 상태(BEFORE_PROGRESS)인 이슈 핀만 수정할 수 있습니다.",
-            )
-
-        location_id, detail_address, user_address = await self._resolve_location_fields(request)
-        image_snapshots = await self._snapshot_upload_images(uploads)
-        user_gps = self._user_coordinates_from_request(request)
-        old_s3_keys = [
-            image.pin_s3_key
-            for image in list(pin.pin_images or [])
-            if (image.pin_s3_key or "").strip()
-        ]
-
-        pin.pin_title = safe_title
-        pin.pin_content = safe_content
-        pin.tone_type = request.tone
-        await self._pin_repo.save(pin, flush_immediately=True)
+            raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_VALIDATION)
 
         pin_location = pin.pin_location
         if pin_location is None:
-            pin_location = PinLocation(
-                pin_id=pin.pin_id,
-                location_id=location_id,
-                detail_address=detail_address,
-                pin_point=wkt_point_from_wgs84(
-                    latitude=request.latitude,
-                    longitude=request.longitude,
-                ),
-            )
-        else:
-            pin_location.location_id = location_id
-            pin_location.detail_address = detail_address
-            pin_location.pin_point = wkt_point_from_wgs84(
-                latitude=request.latitude,
-                longitude=request.longitude,
-            )
-        await self._pin_location_repo.save(pin_location, flush_immediately=True)
+            raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_FAILED)
 
-        await self._pin_image_repo.delete_by_pin_id(pin.pin_id)
-        pin.pin_images = []
-        saved_images = await self._upload_pin_images_sync(
+        existing_images = list(pin.pin_images or [])
+        image_plan = await self._build_update_pin_image_plan(
             pin_id=pin.pin_id,
-            snapshots=image_snapshots,
+            existing_images=existing_images,
+            request=request,
+            photos=uploads,
         )
+
+        if safe_title != pin.pin_title or safe_content != pin.pin_content:
+            pin.pin_title = safe_title
+            pin.pin_content = safe_content
+            await self._pin_repo.save(pin, flush_immediately=True)
+
+        saved_images: list[PinImage]
+        if image_plan.images_unchanged:
+            saved_images = existing_images
+        else:
+            saved_images = await self._sync_pin_images_after_update(
+                pin_id=pin.pin_id,
+                plan=image_plan,
+            )
+
+        user_gps = self._user_gps_from_pin_location(pin_location)
+        user_address = (pin_location.detail_address or "").strip() or None
 
         await self._issue_pin_repo.reset_confidence(issue_pin.issue_pin_id)
         await self._background_runner.cancel(pin_id=pin.pin_id)
-        await self._pin_repo.commit()
-        if old_s3_keys:
-            deleted_count = await self._s3_util.delete_objects_best_effort(old_s3_keys)
+        try:
+            await self._pin_repo.commit()
+        except Exception:
+            await self._pin_repo.rollback()
+            logger.exception("issue pin update commit failed pin_id=%s", pin.pin_id)
+            raise_business_exception(ErrorCode.ISSUE_PIN_EDIT_FAILED)
+
+        if image_plan.removed_s3_keys:
+            deleted_count = await self._s3_util.delete_objects_best_effort(
+                list(image_plan.removed_s3_keys),
+            )
             logger.info(
-                "issue pin update old image S3 cleanup pin_id=%s deleted=%s requested=%s",
+                "issue pin update removed image S3 cleanup pin_id=%s deleted=%s requested=%s",
                 pin.pin_id,
                 deleted_count,
-                len(old_s3_keys),
+                len(image_plan.removed_s3_keys),
             )
 
         await self._background_runner.schedule(
@@ -539,7 +738,7 @@ class IssueService:
             background_tasks=background_tasks,
         )
         image_status = (
-            ImageUploadStatus.COMPLETED if image_snapshots else ImageUploadStatus.NONE
+            ImageUploadStatus.COMPLETED if saved_images else ImageUploadStatus.NONE
         )
 
         return await self._build_issue_pin_home_response(

--- a/app/services/internal/ai/IssuePinLLMService.py
+++ b/app/services/internal/ai/IssuePinLLMService.py
@@ -19,7 +19,7 @@ class IssuePinLLMService:
     api_key: str
     model_name: str = "gemini-2.5-flash"
     client: genai.Client = field(init=False, repr=False)
-    fallback_models: tuple[str, ...] = ("gemini-2.5-flash-lite", "gemini-2.0-flash-lite")
+    fallback_models: tuple[str, ...] = ("gemini-2.5-flash-lite", "gemini-2.5-flash")
 
     def __post_init__(self) -> None:
         self.client = genai.Client(api_key=self.api_key)

--- a/app/services/internal/ai/IssueRagPlannerService.py
+++ b/app/services/internal/ai/IssueRagPlannerService.py
@@ -71,9 +71,9 @@ def _normalize_string_list(value: object) -> list[str]:
 @dataclass(slots=True)
 class IssueRagPlannerService:
     api_key: str
-    model_name: str = "gemini-2.5-flash"
+    model_name: str = "gemini-2.5-flash-lite"
     client: genai.Client = field(init=False, repr=False)
-    fallback_models: tuple[str, ...] = ("gemini-2.5-flash-lite", "gemini-2.0-flash-lite")
+    fallback_models: tuple[str, ...] = ("gemini-2.5-flash",)
 
     def __post_init__(self) -> None:
         self.client = genai.Client(api_key=self.api_key)

--- a/app/utils/geo.py
+++ b/app/utils/geo.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
-from geoalchemy2.elements import WKTElement
+from geoalchemy2.elements import WKBElement, WKTElement
+from geoalchemy2.shape import to_shape
 
 
 def wkt_point_from_wgs84(*, latitude: float, longitude: float) -> WKTElement:
     """WGS84 Point for PostGIS geometry(Point,4326). WKT order is longitude latitude."""
     return WKTElement(f"POINT({longitude} {latitude})", srid=4326)
+
+
+def wgs84_from_pin_point(pin_point: WKBElement) -> tuple[float, float]:
+    """geometry(Point,4326) → (latitude, longitude)."""
+    point = to_shape(pin_point)
+    return float(point.y), float(point.x)
+
+
+def user_gps_from_wgs84(*, latitude: float, longitude: float) -> str:
+    return f"{latitude:.6f},{longitude:.6f}"

--- a/app/utils/openapi_multipart.py
+++ b/app/utils/openapi_multipart.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+def register_pydantic_models(openapi_schema: dict[str, Any], *models: type[BaseModel]) -> None:
+    components = openapi_schema.setdefault("components", {}).setdefault("schemas", {})
+    for model in models:
+        raw = model.model_json_schema(by_alias=True, ref_template="#/components/schemas/{model}")
+        defs = raw.pop("$defs", {})
+        for name, schema in defs.items():
+            components.setdefault(name, schema)
+        components[model.__name__] = raw
+
+
+def patch_multipart_json_request_field(
+    openapi_schema: dict[str, Any],
+    *,
+    body_schema_key: str,
+    request_model: type[BaseModel],
+    description: str,
+    example: dict[str, Any] | None = None,
+) -> None:
+    components = openapi_schema.get("components", {}).get("schemas", {})
+    body = components.get(body_schema_key)
+    if body is None:
+        return
+
+    request_schema: dict[str, Any] = {
+        "allOf": [{"$ref": f"#/components/schemas/{request_model.__name__}"}],
+        "description": description,
+    }
+    if example is not None:
+        request_schema["example"] = example
+
+    body.setdefault("properties", {})["request"] = request_schema

--- a/docs/issue-pin-create-and-reliability.md
+++ b/docs/issue-pin-create-and-reliability.md
@@ -155,32 +155,53 @@ AI 미리보기. **DB 저장 없음.**
 
 ### 4.3 `POST /issues/pin` (신규 핵심)
 
-실제 게시.
+실제 게시. **multipart/form-data** — `request`(JSON part) + `photos`(선택).
 
-| Form 필드 | 필수 | 설명 |
-|-----------|------|------|
-| title | O | **최종** 제목 (AI 초안 수정본 가능) |
-| content | O | **최종** 본문 |
-| tone | O | `ToneType` (한국어 value) |
-| latitude | O | 위도 |
-| longitude | O | 경도 |
-| images | X | 0~N장 multipart 파일 |
+| 파트 | 필수 | 설명 |
+|------|------|------|
+| `request` | O | JSON. `lat`, `lng`, `pinTitle`, `pinContent`, `pinImages[]` |
+| `photos` | X | 이미지 파일 0~5장 (합계 50MB) |
+
+**`request` JSON**
+
+| 필드 | 필수 | 설명 |
+|------|------|------|
+| `lat` | O | 위도 (-90~90) |
+| `lng` | O | 경도 (-180~180) |
+| `pinTitle` | O | **최종** 제목 |
+| `pinContent` | O | **최종** 본문 |
+| `pinImages` | O | `{ isMain }[]` — `photos`와 동일 길이 (0장이면 `[]`) |
+
+- **`toneType` 미수신** → DB `ToneType.NONE` 고정
+- `photos` ↔ `pinImages[]` 인덱스 1:1, `isMain` 합산 정확히 1개(이미지 1장 이상 시)
+- S3 업로드 후 DB/commit 실패 시 신규 S3 객체 롤백 삭제 시도
 
 **HTTP**: `201 Created`  
-**성공 코드**: `COMMON_201`  
+**성공 코드**: `ISSUE_PIN_IMPORT_201`  
 **응답 body**: `IssuePinHomeDetailResponse` (camelCase, Spring 홈 상세 형태)
+
+**에러 코드**
+
+| code | 상황 |
+|------|------|
+| `ISSUE_PIN_IMPORT_400_1` | 필수값/개수/isMain 검증 실패 |
+| `ISSUE_PIN_IMPORT_400_2` | 역지오코딩·DB 저장 실패 |
+| `PIN_IMAGE_400_1` | photos 합계 50MB 초과 |
+| `PIN_IMAGE_400_2` | 업로드/검증/S3 실패 |
+| `PIN_IMAGE_400_3` | 5장 초과 |
+| `USER_4041` | 사용자 없음 |
 
 **동기 처리 순서** (`IssueService.create_issue_pin`):
 
-1. payload 검증 (제목/본문/이미지 개수)
+1. payload 검증 (제목/본문, photos↔pinImages, isMain, 5장/50MB)
 2. 사용자 존재 확인
-3. `LocationResolveClient.resolve_wgs84` → 실패 시 422
-4. `_snapshot_upload_images` — multipart → `ImageSnapshot(bytes)` 
-5. `Pin` INSERT
+3. `LocationResolveClient.resolve_wgs84` → 실패 시 `ISSUE_PIN_IMPORT_400_2`
+4. `_snapshot_update_photos` — multipart → `ImageSnapshot(bytes)`
+5. `Pin` INSERT (`tone_type=NONE`)
 6. `IssuePin` INSERT (`issue_confidence=None`, `confidence_content=None`, `BEFORE_PROGRESS`)
 7. `PinLocation` INSERT (`location_id`, `detail_address`, `pin_point` WKT)
-8. `_upload_pin_images_sync` — S3 `issueimage/{timestamp}-{uuid}.{ext}` + `pin_image`
-9. `commit`
+8. `_upload_new_pin_images_with_is_main` — S3 + `pin_image` (`isMain` per `pinImages`)
+9. `commit` (실패 시 S3 롤백)
 10. `IssuePinBackgroundRunner.schedule(job, background_tasks=...)`
 11. 홈 상세 응답 조립 (`reliabilityStatus=pending`)
 
@@ -215,20 +236,46 @@ AI 미리보기. **DB 저장 없음.**
 
 ### 4.6 `PATCH /issues/pin/{pin_id}`
 
-이슈 핀 수정.
+이슈 핀 수정. **multipart/form-data** — `request`(JSON part) + `photos`(선택).
 
-**성공 코드**: `COMMON_200`  
+**성공 코드**: `ISSUE_PIN_EDIT_200`  
 **응답**: `IssuePinHomeDetailResponse`
 
-**수정 제약**
-- 작성자 본인(`pin.uid == uid`)만 수정 가능 (`COMMON_403`)
-- `issue_pin_state == BEFORE_PROGRESS`일 때만 수정 가능 (`COMMON_422`)
-- 수정 후 신뢰도는 `issue_confidence/confidence_content = NULL`로 초기화되고 재분석이 재스케줄됨
-- 이미지는 전체 교체 방식(기존 `pin_image` 삭제 후 신규 업로드)으로 처리
+**요청**
 
-**신뢰도 파이프라인 처리**
-- 수정 요청 시 기존 `pin_id`의 진행 중 신뢰도 작업 취소를 시도
-- 취소가 불가능한 작업(이미 실행 중 `BackgroundTasks`)은 generation 검증으로 결과 반영을 차단
+| 파트 | 필수 | 설명 |
+|------|------|------|
+| `request` | O | JSON. `pinTitle`, `pinContent`, 선택 `pinImageUrls`, `photos` 있을 때 `pinImages` |
+| `photos` | X | 신규 이미지 파일 배열 (최대 5장, 합계 50MB) |
+
+**`request` JSON**
+
+- `pinImageUrls` **생략** + `photos` 없음 → 기존 이미지 유지 (제목/본문만 수정)
+- `pinImageUrls: []` → 기존 이미지 전부 삭제
+- `pinImageUrls: [{ pinImageUrl, isMain }]` → URL 일치 `pin_image` 행 재사용(`pin_image_id` 유지)
+- `photos` ↔ `pinImages[]` 인덱스 1:1, `isMain` 합산 정확히 1개(이미지 1장 이상 시)
+
+**수정 제약**
+- 작성자 본인만 수정 (`COMMON_403`)
+- `issue_pin_state == BEFORE_PROGRESS`만 수정 (`ISSUE_PIN_EDIT_400_1`)
+- **toneType·위도·경도·region 변경 불가** (DB 기존 값 유지)
+- `pin.updated_at`은 title/content 변경 시에만 갱신 (이미지만 변경 시 pin row 미갱신)
+- S3 업로드 후 DB 실패 시 신규 S3 객체 롤백 삭제 시도
+
+**에러 코드**
+
+| code | 상황 |
+|------|------|
+| `ISSUE_PIN_EDIT_400_1` | 필수값/isMain/개수/URL 검증 실패 |
+| `ISSUE_PIN_EDIT_400_2` | DB 저장 등 처리 실패 |
+| `PIN_IMAGE_400_1` | 신규 photos 합계 50MB 초과 |
+| `PIN_IMAGE_400_2` | 업로드/검증/S3 실패 |
+| `PIN_IMAGE_400_3` | 최종 5장 초과 |
+| `USER_4041` | 사용자 없음 |
+
+**신뢰도 파이프라인**
+- 수정 후 `issue_confidence`/`confidence_content` NULL 초기화 + 재스케줄 (기존 GPS는 `pin_location.pin_point`에서 추출)
+- 진행 중 job 취소 시도, generation 검증으로 stale 결과 차단
 
 ---
 
@@ -265,8 +312,9 @@ AI 미리보기. **DB 저장 없음.**
 
 ### 6.1 이미지 스냅샷
 
-- `_snapshot_upload_images`: `UploadFile.read()` → `ImageSnapshot(data, content_type, filename)`
-- 빈 파일·비이미지 MIME → 422 / 415
+- `_snapshot_update_photos`: `UploadFile.read()` → `ImageSnapshot(data, content_type, filename)`
+- 빈 파일·비이미지 MIME·허용 확장자 외 → `PIN_IMAGE_400_2`
+- 합계 50MB 초과 → `PIN_IMAGE_400_1`
 
 ### 6.2 S3 업로드
 
@@ -274,17 +322,20 @@ AI 미리보기. **DB 저장 없음.**
 - 메서드: `S3Util.upload_bytes` (신규)
 - 키 형식: `issueimage/{UTC timestamp}-{uuid}{ext}`
 - 병렬: `asyncio.gather` per snapshot
-- DB: `PinImageRepo.save` — `pin_s3_key`, `pin_s3_url`, `is_main` (첫 장 main)
+- DB: `PinImageRepo.save` — `pin_s3_key`, `pin_s3_url`, `is_main` (`pinImages[].isMain`)
+- 구현: `_upload_new_pin_images_with_is_main` (PATCH와 공통)
 
 ### 6.3 위치
 
 - `pin_location.location_id` = Spring resolve 응답 `locationId`
 - `detail_address` = resolve `address` (최대 150자)
 - `pin_point` = `wkt_point_from_wgs84` (`app/utils/geo.py`, SRID 4326)
+- 요청 좌표: JSON `lat` / `lng`
 
 ### 6.4 tone_type DB 저장
 
-- API: `ToneType` 한국어 **value** (Form)
+- **등록 API**: `toneType` 미수신 → DB **`NONE`** 고정
+- **`POST /issues/pin/ai`**: `ToneType` 한국어 **value** (Form)
 - ORM/DB: enum **name** 저장 (`NONE`, `DISCOMFORT_COMPLAINT`, …)
 - DB check constraint에 모든 name 허용 필요 (로컬·AWS 각각 마이그레이션 이슈 있었음)
 
@@ -410,7 +461,7 @@ class IssuePinReliabilityJob:
 | `GEMINI_VLM_MODEL` | `gemini-2.5-flash` | 신뢰도 VLM (3.1-pro는 503·지연 多) |
 | `GEMINI_VLM_FALLBACK_MODELS` | `gemini-2.5-flash,gemini-2.5-pro` | 콤마 구분 |
 | `GEMINI_PIN_TEXT_MODEL` | `gemini-2.5-flash` | /pin/ai 핀 LLM |
-| `GEMINI_PIN_TEXT_FALLBACK_MODELS` | `gemini-2.5-flash-lite,gemini-2.0-flash-lite` | |
+| `GEMINI_PIN_TEXT_FALLBACK_MODELS` | `gemini-2.5-flash-lite,gemini-2.5-flash` | |
 | `LOCATION_CORE_BASE_URL` | `http://localhost:8080` | Spring resolve |
 | `LOCATION_RESOLVE_TIMEOUT_SECONDS` | `10.0` | |
 | `AWS_BUCKET` | - | S3 버킷 |
@@ -487,15 +538,15 @@ class IssuePinReliabilityJob:
 ### 12.1 `app/routes/IssueRoute.py`
 
 - `POST /issues/pin` 추가 (`BackgroundTasks` 주입)
-- `PATCH /issues/pin/{pin_id}` 추가 (`multipart/form-data`, 이미지 전체 교체)
+- `PATCH /issues/pin/{pin_id}` 추가 (`multipart/form-data`, `request` JSON + `photos`, URL 재사용·선택 삭제)
 - `GET /issues/pin/{issue_pin_id}` 추가
 - `GET /issues/pin/{pin_id}/reliability` 추가
 
 ### 12.2 `app/services/IssueService.py`
 
-- `create_issue_pin` 전체 구현
-- `update_issue_pin` 추가 (작성자/상태 검증, 이미지 교체, 신뢰도 초기화·재스케줄)
-- `_snapshot_upload_images`, `_upload_pin_images_sync`
+- `create_issue_pin` multipart `request` JSON + `photos`, isMain·S3 롤백
+- `update_issue_pin` 추가 (작성자/상태 검증, URL 재사용·선택 삭제·신규 업로드, 신뢰도 초기화·재스케줄)
+- `_snapshot_update_photos`, `_upload_new_pin_images_with_is_main`
 - `_build_issue_pin_home_response`, `get_issue_pin_detail`, `get_issue_pin_reliability`
 - `_derive_reliability_status`, `_derive_image_upload_status`
 - 의존성: PinLocationRepo, PinImageRepo, PinLikeRepo, CommunityRepo, S3Util, IssuePinBackgroundRunner
@@ -631,9 +682,11 @@ class IssuePinReliabilityJob:
 | 코드 | 상황 |
 |------|------|
 | `USER_4041` | 사용자 없음 |
-| `COMMON_422` | 위치 resolve 실패, 빈 제목/본문, 길이 초과 |
-| `FILE_4001` | S3 업로드 실패 |
-| `FILE_4151` | 비이미지 파일 |
+| `ISSUE_PIN_IMPORT_400_1` | 필수값/개수/isMain 검증 실패 |
+| `ISSUE_PIN_IMPORT_400_2` | 역지오코딩·DB 저장 실패 |
+| `PIN_IMAGE_400_1` | photos 합계 50MB 초과 |
+| `PIN_IMAGE_400_2` | 업로드/검증/S3 실패 |
+| `PIN_IMAGE_400_3` | 5장 초과 |
 
 **미사용**: `ISSUE_4221` (신뢰도 낮아 게시 거절) — 정책상 게시는 항상 허용
 
@@ -641,7 +694,8 @@ class IssuePinReliabilityJob:
 
 | 코드 | API |
 |------|-----|
-| `COMMON_201` | POST /issues/pin, /pin/ai |
+| `COMMON_201` | POST /issues/pin/ai |
+| `ISSUE_PIN_IMPORT_201` | POST /issues/pin |
 | `ISSUE_2001` | GET /issues/pin/{id} |
 | `ISSUE_2002` | GET /issues/pin/{id}/reliability |
 
@@ -657,14 +711,14 @@ class IssuePinReliabilityJob:
 
 ## 17. 프론트엔드 연동 체크리스트
 
-- [ ] `POST /issues/pin/ai` → 편집 → `POST /issues/pin` 2단계
+- [ ] `POST /issues/pin/ai` → 편집 → `POST /issues/pin` 2단계 (`request` JSON + `photos`)
 - [ ] 게시 응답 `reliabilityStatus === 'pending'` 이면 신뢰도 폴링
 - [ ] `GET /issues/pin/{pin_id}/reliability` 또는 상세에서 `issueConfidence`, `confidenceContent` 표시
 - [ ] `confidenceContent` 줄바꿈 (`\n`) 렌더링
 - [ ] `reliabilityStatus === 'failed'` 시 재시도 안내 UI
-- [ ] 이미지 0장 게시 지원
-- [ ] `tone` Form 값은 한국어 label (`없음`, …)
-- [ ] 게시 시 `latitude`/`longitude` 필수
+- [ ] 이미지 0장 게시 지원 (`pinImages: []`)
+- [ ] 게시 시 JSON `lat`/`lng` 필수, `pinImages[].isMain` (이미지 1장 이상)
+- [ ] `/pin/ai`만 `tone` Form (한국어 label)
 
 ---
 

--- a/rag/scripts/test_create_issue_pin_once.py
+++ b/rag/scripts/test_create_issue_pin_once.py
@@ -35,11 +35,10 @@ async def _run(
     longitude: float,
 ) -> None:
     from app.core.config import settings
-    from app.models.enum.ToneType import ToneType
     from app.repositories.IssuePinRepo import IssuePinRepo
     from app.repositories.PinRepo import PinRepo
     from app.repositories.UserRepo import UserRepo
-    from app.schemas.IssueDTO import CreateIssuePinRequest
+    from app.schemas.IssueDTO import CreateIssuePinMultipartRequest, PinImageIsMainItem
     from app.services.internal.geo.ImageExifLocationResolveService import ImageExifLocationResolveService
     from app.services.internal.geo.ImageMultipartGeoService import ImageMultipartGeoService
     from app.services.internal.ai.IssuePinLLMService import IssuePinLLMService
@@ -64,12 +63,12 @@ async def _run(
         headers=Headers({"content-type": mime}),
     )
 
-    request = CreateIssuePinRequest(
-        title=title,
-        content=content,
-        tone=ToneType.SITUATION_DESCRIPTION,
-        latitude=latitude,
-        longitude=longitude,
+    request = CreateIssuePinMultipartRequest(
+        lat=latitude,
+        lng=longitude,
+        pin_title=title,
+        pin_content=content,
+        pin_images=[PinImageIsMainItem(is_main=True)],
     )
 
     pin_repo = MagicMock(spec=PinRepo)
@@ -117,17 +116,23 @@ async def _run(
 
         service = IssueService(
             vector_store_service=vector_store,
-            vlm_service=vlm,
-            image_exif_location_resolve_service=exif_service,
+            issue_rag_planner_service=MagicMock(),
+            location_resolve_client=location_resolve,
             issue_pin_llm_service=pin_llm,
             pin_repo=pin_repo,
             issue_pin_repo=issue_pin_repo,
+            pin_location_repo=MagicMock(),
+            pin_image_repo=MagicMock(),
+            pin_like_repo=MagicMock(),
+            community_repo=MagicMock(),
             user_repo=user_repo,
+            s3_util=MagicMock(),
+            background_runner=MagicMock(),
         )
 
         result = await service.create_issue_pin(
             uid="script-test-user",
-            images=[upload],
+            photos=[upload],
             request=request,
         )
         print(result.model_dump_json(indent=2, ensure_ascii=False))

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ freetype-py==2.5.1
 frozenlist==1.8.0
 fsspec==2026.4.0
 GeoAlchemy2==0.18.0
+shapely==2.1.2
 google-ai-generativelanguage==0.6.15
 google-api-core==2.30.3
 google-api-python-client==2.194.0


### PR DESCRIPTION

## 🔗 Related Issue
- resolve #99 

## ✨ 작업 개요

**POST `/issues/pin`**
  - 기존 Form 필드(`title`, `content`, `tone`, `latitude`, `longitude`, `images`) → `request`(JSON) + `photos`
  - 성공: `201` + `ISSUE_PIN_IMPORT_201`
  - `toneType` 미수신 → DB `NONE` 고정
- **PATCH `/issues/pin/{pin_id}`**
  - 동일 multipart 형식 (`pinImageUrls` 유지 + `pinImages`/`photos` 신규)
  - 성공: `200` + `ISSUE_PIN_EDIT_200`
  - `BEFORE_PROGRESS` + 작성자 본인만 수정, 좌표·region 변경 불가
- **검증·이미지 처리**
  - `photos` ↔ `pinImages` 1:1 매칭, 이미지 1장 이상 시 `isMain` true 정확히 1개
  - 수정 시 `pin_image` URL 재사용, 미포함 이미지 삭제, S3 업로드 실패·DB 실패 시 롤백
- **에러/성공 코드**
  - `ISSUE_PIN_IMPORT_400_1/2`, `ISSUE_PIN_EDIT_400_1/2`, `PIN_IMAGE_400_1~3` 추가
- **기타**
  - `PinImageRepo`: URL 조회·일괄 삭제
  - `shapely` 의존성 추가, `geo.py` WKT 처리 보완 (PATCH 후 GPS 추출 500 해결)
  - Swagger multipart `request` JSON 스키마 노출 (`openapi_multipart.py`)
  - RAG Planner 전용 Gemini 모델 설정 분리 (`GEMINI_RAG_PLANNER_*`)
  - `docs/issue-pin-create-and-reliability.md` 갱신

- `POST /issues/pin`, `PATCH /issues/pin/{pin_id}` 요청 형식 변경 (Spring 소통 핀 API와 동일 contract)
- 등록 성공 코드: `COMMON_201` → **`ISSUE_PIN_IMPORT_201`**
- 수정 API 신규 노출 (기존 Form 기반과 호환 없음)

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [x] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
<img width="1479" height="1061" alt="image" src="https://github.com/user-attachments/assets/29fcc80b-a651-4e5c-95db-00ef75b07919" />
<img width="1479" height="1061" alt="image" src="https://github.com/user-attachments/assets/771c607d-087c-4909-95cd-6b03b5b0d46d" />
<img width="1479" height="1061" alt="image" src="https://github.com/user-attachments/assets/df530fb9-8e45-47d9-8676-8577d773f30c" />
<img width="1479" height="592" alt="image" src="https://github.com/user-attachments/assets/eb37e08d-cea7-4c60-844d-bd08ac305768" />



## 🧐 집중 리뷰 요청
 `IssueService.create_issue_pin` / `update_issue_pin` — 이미지 플랜·S3 롤백·`updated_at` 갱신 조건
- `IssueService._build_update_pin_image_plan` — `pinImageUrls` 생략 vs `[]` vs 기존 URL 재사용/삭제 분기
- `PATCH` 후 신뢰도 reset + background job 재스케줄 동작
- RAG Planner 모델 설정 분리 및 `ISSUE_PIN_RELIABILITY_SKIP_RAG_PLANNER` 기본값 `false` 변경 영향


##API 명세서
https://www.notion.so/33fc2d48bf00800d94c5ddbe16fa45f6?v=33fc2d48bf0081c5b5c7000ca5b2067c&source=copy_link