### PR TITLE
hotfix: 병렬 이미지 업로드 실패 시 S3 고아 객체 누수 방지

### DIFF
--- a/app/services/IssueService.py
+++ b/app/services/IssueService.py
@@ -505,7 +505,9 @@ class IssueService:
             return saved, uploaded_keys
         finally:
             if not success and uploaded_keys:
-                await self._s3_util.delete_objects_best_effort(uploaded_keys)
+                await asyncio.shield(
+                    self._s3_util.delete_objects_best_effort(uploaded_keys),
+                )
 
     async def _sync_pin_images_after_update(
         self,

--- a/app/services/IssueService.py
+++ b/app/services/IssueService.py
@@ -466,37 +466,46 @@ class IssueService:
             return [], []
 
         uploaded_keys: list[str] = []
+        success = False
 
         async def upload_and_track(snap: ImageSnapshot) -> dict[str, str]:
             uploaded = await self._upload_snapshot_to_s3(snap)
             uploaded_keys.append(uploaded["key"])
             return uploaded
 
-        uploaded_list = await asyncio.gather(
-            *[upload_and_track(snap) for snap, _ in new_specs],
-            return_exceptions=True,
-        )
-        failures = [result for result in uploaded_list if isinstance(result, BaseException)]
-        if failures:
-            if uploaded_keys:
-                await self._s3_util.delete_objects_best_effort(uploaded_keys)
-            logger.error(
-                "issue pin image S3 upload failed pin_id=%s",
-                pin_id,
-                exc_info=failures[0],
+        try:
+            uploaded_list = await asyncio.gather(
+                *[upload_and_track(snap) for snap, _ in new_specs],
+                return_exceptions=True,
             )
-            raise_business_exception(ErrorCode.PIN_IMAGE_UPLOAD_FAILED)
+            failures = [
+                result for result in uploaded_list if isinstance(result, BaseException)
+            ]
+            if failures:
+                first_failure = failures[0]
+                if not isinstance(first_failure, Exception):
+                    raise first_failure
+                logger.error(
+                    "issue pin image S3 upload failed pin_id=%s",
+                    pin_id,
+                    exc_info=first_failure,
+                )
+                raise_business_exception(ErrorCode.PIN_IMAGE_UPLOAD_FAILED)
 
-        saved: list[PinImage] = []
-        for (snap, is_main), uploaded in zip(new_specs, uploaded_list, strict=True):
-            pin_image = PinImage(
-                pin_id=pin_id,
-                pin_s3_key=uploaded["key"],
-                pin_s3_url=uploaded["url"],
-                is_main=is_main,
-            )
-            saved.append(pin_image)
-        return saved, uploaded_keys
+            saved: list[PinImage] = []
+            for (snap, is_main), uploaded in zip(new_specs, uploaded_list, strict=True):
+                pin_image = PinImage(
+                    pin_id=pin_id,
+                    pin_s3_key=uploaded["key"],
+                    pin_s3_url=uploaded["url"],
+                    is_main=is_main,
+                )
+                saved.append(pin_image)
+            success = True
+            return saved, uploaded_keys
+        finally:
+            if not success and uploaded_keys:
+                await self._s3_util.delete_objects_best_effort(uploaded_keys)
 
     async def _sync_pin_images_after_update(
         self,

--- a/app/services/IssueService.py
+++ b/app/services/IssueService.py
@@ -472,14 +472,19 @@ class IssueService:
             uploaded_keys.append(uploaded["key"])
             return uploaded
 
-        try:
-            uploaded_list = await asyncio.gather(
-                *[upload_and_track(snap) for snap, _ in new_specs],
-            )
-        except Exception:
+        uploaded_list = await asyncio.gather(
+            *[upload_and_track(snap) for snap, _ in new_specs],
+            return_exceptions=True,
+        )
+        failures = [result for result in uploaded_list if isinstance(result, BaseException)]
+        if failures:
             if uploaded_keys:
                 await self._s3_util.delete_objects_best_effort(uploaded_keys)
-            logger.exception("issue pin image S3 upload failed pin_id=%s", pin_id)
+            logger.error(
+                "issue pin image S3 upload failed pin_id=%s",
+                pin_id,
+                exc_info=failures[0],
+            )
             raise_business_exception(ErrorCode.PIN_IMAGE_UPLOAD_FAILED)
 
         saved: list[PinImage] = []


### PR DESCRIPTION

asyncio.gather에 return_exceptions=True를 적용해 모든 업로드 태스크 완료 후
실패를 판별하고, 실패 시 업로드된 S3 객체를 일괄 삭제하도록 개선