### PR TITLE
hotfix: 공모전 슬라이드 빈 필터를 정규화 이후에 수행

### DIFF
--- a/app/contest_cardnews/copy.py
+++ b/app/contest_cardnews/copy.py
@@ -137,10 +137,14 @@ def is_contest_slide_empty(slide: dict[str, Any]) -> bool:
             or bool(str(slide.get("headline") or "").strip())
         )
     if slide.get("items"):
-        return len([i for i in slide["items"] if str(i.get("text") or "").strip()]) == 0
+        return len([
+            i for i in slide["items"]
+            if (str(i.get("text") or "").strip() if isinstance(i, dict) else str(i).strip())
+        ]) == 0
     return not bool(str(slide.get("body") or slide.get("headline") or "").strip())
 
 
 def prepare_contest_slides(slides: list[dict[str, Any]]) -> list[dict[str, Any]]:
     rows = compact_contest_deck(slides)
-    return [normalize_contest_slide_copy(s) for s in rows if not is_contest_slide_empty(s)]
+    normalized = [normalize_contest_slide_copy(s) for s in rows]
+    return [s for s in normalized if not is_contest_slide_empty(s)]


### PR DESCRIPTION
Summary
공모전 카드뉴스 렌더링 중 prepare_contest_slides가 슬라이드 정규화 전에 빈 슬라이드 여부를 판단하여, LLM이 반환한 items 형식에 따라 오류 또는 슬라이드 누락이 발생할 수 있는 문제를 수정합니다.

prepare_contest_slides: normalize_contest_slide_copy 적용 후 is_contest_slide_empty로 필터링하도록 순서 변경
is_contest_slide_empty: items에 문자열이 포함된 경우 AttributeError가 발생하지 않도록 방어 처리 추가
value / content 키만 있는 항목이 정규화 전에 빈 슬라이드로 잘못 제외되던 문제 해소


배경
prepare_contest_slides에서 리스트 컴프리헨션 필터가 정규화보다 먼저 실행되어, 원본 슬라이드에 대해 is_contest_slide_empty가 호출되고 있었습니다.

items에 문자열이 포함되면 i.get("text") 호출 시 AttributeError로 렌더링 파이프라인이 중단될 수 있음
{"value": "..."} 형태 항목은 정규화 전에는 텍스트가 없는 것으로 판단되어 유효한 슬라이드가 누락될 수 있음
